### PR TITLE
✨ Feat: 전역 예외 처리 기능 추가

### DIFF
--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/common/exception/CustomException.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/common/exception/CustomException.kt
@@ -1,0 +1,7 @@
+package com.challengeteamkotlin.campdaddy.common.exception
+
+import com.challengeteamkotlin.campdaddy.common.exception.code.ErrorCode
+
+open class CustomException(
+    open val errorCode: ErrorCode
+) : RuntimeException()

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/common/exception/EntityNotFoundException.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/common/exception/EntityNotFoundException.kt
@@ -1,0 +1,7 @@
+package com.challengeteamkotlin.campdaddy.common.exception
+
+import com.challengeteamkotlin.campdaddy.common.exception.code.ErrorCode
+
+class EntityNotFoundException(
+    override val errorCode: ErrorCode
+) : CustomException(errorCode)

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/common/exception/advice/RestApiExceptionAdvice.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/common/exception/advice/RestApiExceptionAdvice.kt
@@ -1,0 +1,29 @@
+package com.challengeteamkotlin.campdaddy.common.exception.advice
+
+import com.challengeteamkotlin.campdaddy.common.exception.CustomException
+import com.challengeteamkotlin.campdaddy.common.exception.code.CommonErrorCode
+import com.challengeteamkotlin.campdaddy.common.exception.dto.response.ErrorResponse
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class RestApiExceptionAdvice {
+
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    @ExceptionHandler
+    fun handleCustomExceptionHandle(exception: CustomException): ResponseEntity<ErrorResponse> {
+        logger.warn("${exception.errorCode.errorMessage}: {}", exception.message)
+        return ErrorResponse.of(exception.errorCode)
+    }
+
+    @ExceptionHandler
+    fun handleMethodArgumentNotValidException(exception: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {
+        logger.warn("Validation Failed: {}", exception.message)
+        val errorCode = CommonErrorCode.VALIDATION_FAILED
+        return ErrorResponse.of(errorCode, exception.bindingResult)
+    }
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/common/exception/code/CommonErrorCode.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/common/exception/code/CommonErrorCode.kt
@@ -1,0 +1,14 @@
+package com.challengeteamkotlin.campdaddy.common.exception.code
+
+import org.springframework.http.HttpStatus
+
+enum class CommonErrorCode(
+    override val id: Long,
+    override val status: HttpStatus,
+    override val errorMessage: String?
+) : ErrorCode {
+    VALIDATION_FAILED(9000, HttpStatus.BAD_REQUEST),
+
+    ;
+    constructor(id: Long, status: HttpStatus) : this(id, status, null)
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/common/exception/code/ErrorCode.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/common/exception/code/ErrorCode.kt
@@ -1,0 +1,9 @@
+package com.challengeteamkotlin.campdaddy.common.exception.code
+
+import org.springframework.http.HttpStatus
+
+interface ErrorCode {
+    val id: Long
+    val status: HttpStatus
+    val errorMessage: String?
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/common/exception/dto/response/ErrorResponse.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/common/exception/dto/response/ErrorResponse.kt
@@ -1,0 +1,33 @@
+package com.challengeteamkotlin.campdaddy.common.exception.dto.response
+
+import com.challengeteamkotlin.campdaddy.common.exception.code.ErrorCode
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.BindingResult
+
+data class ErrorResponse(
+    val errorId: Long,
+    val payload: Any? = null
+) {
+
+    companion object {
+
+        fun of(errorCode: ErrorCode): ResponseEntity<ErrorResponse> =
+            ResponseEntity.status(errorCode.status).body(makeResponse(errorCode))
+
+        fun of(errorCode: ErrorCode, bindingResult: BindingResult): ResponseEntity<ErrorResponse> =
+            ResponseEntity.status(errorCode.status).body(makeResponse(errorCode, bindingResult))
+
+        private fun makeResponse(errorCode: ErrorCode) = ErrorResponse(errorCode.id, errorCode.errorMessage)
+
+        private fun makeResponse(errorCode: ErrorCode, bindingResult: BindingResult): ErrorResponse {
+            val errorMap = hashMapOf<String, String>()
+
+            bindingResult.fieldErrors.map {
+                errorMap[it.rejectedValue] to it.defaultMessage
+            }
+
+            return ErrorResponse(errorCode.id, errorMap)
+        }
+    }
+
+}


### PR DESCRIPTION
## 연관 이슈
- closes #10 

## 해당 작업을 추가/변경한 이유는 무엇인가요?
- @RestControllerAdvice과 @ExceptionHandler를 통해 Exception 발생 시 예외의 처리를 관리할 때 최소 개수의 메서드로만 관리할 수 있으면 좋겠다고 생각하였습니다.
    ```kotlin
    @ExceptionHandler
    fun handleCustomExceptionHandle(exception: CustomException): ResponseEntity<ErrorResponse> {
        logger.warn("${exception.errorCode.errorMessage}: {}", exception.message)
        return ErrorResponse.of(exception.errorCode)
    }
    ```
- 최소한으로 처리를 하기 위해서는 RuntimeException을 상속받는 CustomException 클래스를 만들어 위 메서드처럼 하나의 메서드로 다양한 커스텀 예외를 관리할 수 있겠다고 느꼈습니다.
- 또한 CustomException에는 ErrorCode 클래스를 생성자 인자로 주입 받아, 어떤 예외가 발생했는지에 따라 ErrorCode를 통해 발생한 예외의 `ID, Http 상태값, 메시지`를 관리할 수 있게 하였습니다.
- ErrorCode는 실제 예외가 핸들링 될 때, 클라이언트에 Response를 반환하기 위한 값으로도 사용됩니다.
- ErrorResponse 클래스는 클라이언트에 예외에 대한 정보를 반환하는 책임을 책임집니다.
- 이와 별개로, Validation 처리 중 발생할 수 있는 예외 중 하나인 MethodArgumentNotValidException은 bindingResult를 프로퍼티로 가지고 있기 때문에 이를 관리할 수 있는 핸들링 메서드를 따로 추가하였습니다.

## 어떤 부분에 리뷰어가 집중하면 좋을까요?
- 이 외에 좋은 개선 사항이나 아이디어 있으시면 자유롭게 의견 내주세요!

## 리뷰어에게 추가/변경 내용을 상세히 설명해주세요!
- [x] ResponseEntity의 Response로 사용할 ErrorResponse 클래스 작성
- [x] 에러 코드 관리를 위한 ErrorCode 클래스 작성
- [x] @RestControllerAdvice를 활용하는 RestApiExceptionAdvice 클래스 작성
- [x] 기본 @ExceptionHandler 메서드 작성
- [x] 커스텀한 예외 처리를 위한 CustomException 클래스 작성
