### PR TITLE
🐛 Bugfix: Entity 생성 버그 파악 및 해결

### DIFF
--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/model/member/MemberEntity.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/model/member/MemberEntity.kt
@@ -26,7 +26,7 @@ class MemberEntity(
     @Column(name = "member_id")
     val id: Long? = null
 
-    @OneToMany(mappedBy = "members", cascade = [CascadeType.ALL] , orphanRemoval = true)
+    @OneToMany(mappedBy = "memberId", cascade = [CascadeType.ALL] , orphanRemoval = true)
     private val regionEntity: List<RegionEntity> = mutableListOf()
 
 }

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/model/product/ProductEntity.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/model/product/ProductEntity.kt
@@ -39,9 +39,9 @@ class ProductEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "product_id")
-    val id :String? =null
+    val id :Long? =null
 
-    @OneToMany(mappedBy = "products")
+    @OneToMany(mappedBy = "productEntity")
     val reviewEntity:List<ReviewEntity> = mutableListOf()
 
 }


### PR DESCRIPTION
## 연관 이슈
- closes #19

## 해당 작업을 추가/변경한 이유는 무엇인가요?
- ProductEntity의 productId가 String으로 되어 있었다.
- ProductEntity의 mappedBy의 name이 잘못 지정 되어 있었음.
- MemberEntity의 mappedBy의 name이 잘못 지정 되어 있었음.

## 어떤 부분에 리뷰어가 집중하면 좋을까요?
- 변경 부분 중 이상한 곳이 있다면 말씀해주시길 바랍니다!

## 리뷰어에게 추가/변경 내용을 상세히 설명해주세요!
- [x] ProductEntity의 productId가 Long으로 변경.
- [x] ProductEntity의 mappedBy의 name을 productEntity로 변경.
- [x] MemberEntity의 mappedBy의 name을 memberId로 변경.
