### PR TITLE
♻️ Refactor: BaseEntity lateinit 키워드 탈거 리팩토링 적용

### DIFF
--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/common/entity/BaseTimeEntity.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/common/entity/BaseTimeEntity.kt
@@ -14,11 +14,11 @@ abstract class BaseTimeEntity {
 
     @Column(name = "created_at", nullable = false, updatable = false)
     @CreatedDate
-    lateinit var createdAt: LocalDateTime
+    var createdAt: LocalDateTime = LocalDateTime.now()
         protected set
 
     @Column(name = "updated_at", nullable = false)
     @LastModifiedDate
-    lateinit var updatedAt: LocalDateTime
+    var updatedAt: LocalDateTime = LocalDateTime.now()
         protected set
 }


### PR DESCRIPTION
- lateinit 키워드 제거 후, LocalDateTime.now()로 변경

## 연관 이슈
- closes #27 

## 해당 작업을 추가/변경한 이유는 무엇인가요?
- 테스트 코드 작성 중 lateinit 키워드에 의해 UninitializedException - lateinit variable has not initialized 예외가 발생하였는데, 테스트 코드 작성에 용이하려면 BaseEntity의 프로퍼티인 createdAt, updatedAt에 lateinit을 빼는게 좋다고 생각하였습니다.

## 어떤 부분에 리뷰어가 집중하면 좋을까요?
- lateinit 및 추상 클래스를 테스트 환경에서 인스턴스로 바꾸는 방법을 알게 되면 다시 lateinit으로 바꿔도 될 것 같습니다.

## 리뷰어에게 추가/변경 내용을 상세히 설명해주세요!
- [x] createdAt, updatedAt의 lateinit 키워드를 탈거하고, LocalDateTime.now() 로 변경하였습니다.