### PR TITLE
✅ Test: 채팅방 & 채팅 메시지 Entity 단위 테스트코드 추가

### DIFF
--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatMessageEntity.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatMessageEntity.kt
@@ -8,7 +8,7 @@ import jakarta.persistence.*
 @Table(name = "chat_messages")
 class ChatMessageEntity(
 
-    @Column(length = 200, nullable = false)
+    @Column
     val message: String,
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -20,10 +20,6 @@ class ChatMessageEntity(
     val chatRoomEntity: ChatRoomEntity,
 
     ) : BaseTimeEntity() {
-
-    init {
-        require(message.isNotEmpty())
-    }
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatMessageEntity.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatMessageEntity.kt
@@ -8,7 +8,7 @@ import jakarta.persistence.*
 @Table(name = "chat_messages")
 class ChatMessageEntity(
 
-    @Column
+    @Column(length = 200, nullable = false)
     val message: String,
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -19,7 +19,11 @@ class ChatMessageEntity(
     @JoinColumn(name = "chat_room_id")
     val chatRoomEntity: ChatRoomEntity,
 
-    ): BaseTimeEntity() {
+    ) : BaseTimeEntity() {
+
+    init {
+        require(message.isNotEmpty())
+    }
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatRoomEntity.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatRoomEntity.kt
@@ -23,4 +23,6 @@ class ChatRoomEntity(
     @Column(name = "chat_room_id")
     val id: Long? = null
 
+    fun validateRoomOwner() = productEntity.memberEntity != memberEntity
+
 }

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatRoomEntity.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatRoomEntity.kt
@@ -23,6 +23,7 @@ class ChatRoomEntity(
     @Column(name = "chat_room_id")
     val id: Long? = null
 
-    fun validateRoomOwner() = productEntity.memberEntity != memberEntity
+    fun validateRoomOwner(): Result<Boolean> =
+        Result.success(productEntity.memberEntity != memberEntity)
 
 }

--- a/src/test/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatMessageTest.kt
+++ b/src/test/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatMessageTest.kt
@@ -1,0 +1,32 @@
+package com.challengeteamkotlin.campdaddy.domain.model.chat
+
+import com.challengeteamkotlin.campdaddy.fixture.chat.ChatRoomFixture.chatRoom
+import com.challengeteamkotlin.campdaddy.fixture.member.MemberFixture.buyer
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+class ChatMessageTest : BehaviorSpec({
+
+    Given("채팅 메시지 생성 테스트") {
+
+        When("새로운 메세지가 생성될 때 공백이 아니면") {
+            lateinit var chat: ChatMessageEntity
+
+            shouldNotThrow<IllegalArgumentException> { ChatMessageEntity("빌려주삼", buyer, chatRoom).also { chat = it } }
+
+            Then("메세지가 저장된다.") {
+                chat.message shouldBe "빌려주삼"
+                chat.chatRoomEntity.memberEntity shouldBe buyer
+                chat.memberEntity shouldBe buyer
+            }
+        }
+
+        When("새로운 메세지가 생성될 때 공백이면") {
+            Then("메세지가 저장되지 않는다.") {
+                shouldThrowExactly<IllegalArgumentException> { ChatMessageEntity("", buyer, chatRoom) }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatMessageTest.kt
+++ b/src/test/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatMessageTest.kt
@@ -2,30 +2,22 @@ package com.challengeteamkotlin.campdaddy.domain.model.chat
 
 import com.challengeteamkotlin.campdaddy.fixture.chat.ChatRoomFixture.chatRoom
 import com.challengeteamkotlin.campdaddy.fixture.member.MemberFixture.buyer
-import io.kotest.assertions.throwables.shouldNotThrow
-import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 
 class ChatMessageTest : BehaviorSpec({
 
     Given("채팅 메시지 생성 테스트") {
 
         When("새로운 메세지가 생성될 때 공백이 아니면") {
-            lateinit var chat: ChatMessageEntity
-
-            shouldNotThrow<IllegalArgumentException> { ChatMessageEntity("빌려주삼", buyer, chatRoom).also { chat = it } }
+            var chat = ChatMessageEntity("빌려주삼", buyer, chatRoom)
 
             Then("메세지가 저장된다.") {
                 chat.message shouldBe "빌려주삼"
+                chat.message shouldNotBe ""
                 chat.chatRoomEntity.memberEntity shouldBe buyer
                 chat.memberEntity shouldBe buyer
-            }
-        }
-
-        When("새로운 메세지가 생성될 때 공백이면") {
-            Then("메세지가 저장되지 않는다.") {
-                shouldThrowExactly<IllegalArgumentException> { ChatMessageEntity("", buyer, chatRoom) }
             }
         }
     }

--- a/src/test/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatRoomTest.kt
+++ b/src/test/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatRoomTest.kt
@@ -4,7 +4,6 @@ import com.challengeteamkotlin.campdaddy.fixture.chat.ChatRoomFixture.chatRoom
 import com.challengeteamkotlin.campdaddy.fixture.chat.ChatRoomFixture.wrongChatRoom
 import com.challengeteamkotlin.campdaddy.fixture.member.MemberFixture.buyer
 import com.challengeteamkotlin.campdaddy.fixture.member.MemberFixture.seller
-import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 
@@ -13,11 +12,11 @@ class ChatRoomTest : BehaviorSpec({
     Given("채팅룸 생성 테스트") {
         When("채팅룸을 만든 멤버가 판매자라면") {
             Then("채팅룸이 생성되지 않는다.") {
-                 wrongChatRoom.validateRoomOwner() shouldBe false
+                 runCatching {  wrongChatRoom.validateRoomOwner() }
+                     .isSuccess shouldBe true
             }
         }
         When("채팅룸을 만든 멤버가 구매자라면") {
-            shouldNotThrow<IllegalArgumentException> { chatRoom }
             Then("채팅룸이 생성된다.") {
                 chatRoom.memberEntity shouldBe buyer
                 chatRoom.productEntity.memberEntity shouldBe seller

--- a/src/test/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatRoomTest.kt
+++ b/src/test/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatRoomTest.kt
@@ -1,0 +1,27 @@
+package com.challengeteamkotlin.campdaddy.domain.model.chat
+
+import com.challengeteamkotlin.campdaddy.fixture.chat.ChatRoomFixture.chatRoom
+import com.challengeteamkotlin.campdaddy.fixture.chat.ChatRoomFixture.wrongChatRoom
+import com.challengeteamkotlin.campdaddy.fixture.member.MemberFixture.buyer
+import com.challengeteamkotlin.campdaddy.fixture.member.MemberFixture.seller
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+class ChatRoomTest : BehaviorSpec({
+
+    Given("채팅룸 생성 테스트") {
+        When("채팅룸을 만든 멤버가 판매자라면") {
+            Then("채팅룸이 생성되지 않는다.") {
+                 wrongChatRoom.validateRoomOwner() shouldBe false
+            }
+        }
+        When("채팅룸을 만든 멤버가 구매자라면") {
+            shouldNotThrow<IllegalArgumentException> { chatRoom }
+            Then("채팅룸이 생성된다.") {
+                chatRoom.memberEntity shouldBe buyer
+                chatRoom.productEntity.memberEntity shouldBe seller
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/chat/ChatMessageFixture.kt
+++ b/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/chat/ChatMessageFixture.kt
@@ -1,0 +1,4 @@
+package com.challengeteamkotlin.campdaddy.fixture.chat
+
+object ChatMessageFixture {
+}

--- a/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/chat/ChatRoomFixture.kt
+++ b/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/chat/ChatRoomFixture.kt
@@ -1,0 +1,11 @@
+package com.challengeteamkotlin.campdaddy.fixture.chat
+
+import com.challengeteamkotlin.campdaddy.domain.model.chat.ChatRoomEntity
+import com.challengeteamkotlin.campdaddy.fixture.member.MemberFixture.buyer
+import com.challengeteamkotlin.campdaddy.fixture.member.MemberFixture.seller
+import com.challengeteamkotlin.campdaddy.fixture.product.ProductFixture.tent
+
+object ChatRoomFixture {
+    val chatRoom = ChatRoomEntity(buyer, tent)
+    val wrongChatRoom = ChatRoomEntity(seller, tent)
+}

--- a/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/member/MemberFixture.kt
+++ b/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/member/MemberFixture.kt
@@ -1,0 +1,9 @@
+package com.challengeteamkotlin.campdaddy.fixture.member
+
+import com.challengeteamkotlin.campdaddy.domain.model.member.MemberEntity
+
+
+object MemberFixture {
+    val buyer = MemberEntity("buyer@google.com", "buyer", "백다삼", "01012345678")
+    val seller = MemberEntity("seller@google.com", "seller", "김다팜", "01087654321")
+}

--- a/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/product/ProductFixture.kt
+++ b/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/product/ProductFixture.kt
@@ -1,0 +1,9 @@
+package com.challengeteamkotlin.campdaddy.fixture.product
+
+import com.challengeteamkotlin.campdaddy.domain.model.product.Category
+import com.challengeteamkotlin.campdaddy.domain.model.product.ProductEntity
+import com.challengeteamkotlin.campdaddy.fixture.member.MemberFixture.seller
+
+object ProductFixture {
+    val tent = ProductEntity(seller, 100_000, null, "텐트 빌려드려요", "텐트 빌려드림ㅇㅇ", Category.TENTS)
+}

--- a/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/reservation/ReservationFixture.kt
+++ b/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/reservation/ReservationFixture.kt
@@ -1,0 +1,5 @@
+package com.challengeteamkotlin.campdaddy.fixture.reservation
+
+object ReservationFixture {
+
+}

--- a/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/review/ReviewFixture.kt
+++ b/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/review/ReviewFixture.kt
@@ -1,0 +1,4 @@
+package com.challengeteamkotlin.campdaddy.fixture.review
+
+object ReviewFixture {
+}


### PR DESCRIPTION
## 연관 이슈
- closes #22 

## 해당 작업을 추가/변경한 이유는 무엇인가요?
- 채팅 도메인 관련 엔티티의 생성과 관련한 단위 테스트를 작성하였습니다.
- 이후 새롭게 추가될 코드 로직이 정책과 맞지 않게 변경 되었을 때 단위 테스트의 동작을 통해 효과적으로 정책 설정과 다른 오류를 검증하고 개선할 수 있습니다.
- 또한, Fixture 클래스를 생성하여 테스트 코드에서는 테스트 코드와 관련된 로직만을 파악하기 쉽게 하였습니다.
- 현재는 Fixture를 직접 생성하여 사용하고 있습니다. 하지만 이후에 다양한 테스트 엔티티, DTO가 필요해질 때는 FixtureMonkey, KotlinFixture 라이브러리 등을 활용하여 fixture를 생성하는 수고를 덜 예정입니다.

## 어떤 부분에 리뷰어가 집중하면 좋을까요?
- Fixture와 관련된 내용은 구두로 다시 설명드리고 전파하겠습니다!

## 리뷰어에게 추가/변경 내용을 상세히 설명해주세요!
- [x] 각 Entity Fixture 클래스 생성 및 Chat 도메인 관련 fixture 생성
- [x] 메시지 생성 정책 관련 ChatMessageEntity 컬럼 길이 추가 및 init 블록 내 공백 검증 메서드 추가
- [x] ChatRoomEntity 채팅방 생성 정책(구매자만 채팅방 생성이 가능함) 관련 검증 메서드 생성
- [x] ChatRoomEntity, ChatMessageEntity Test 코드 작성

