### PR TITLE
✅ Test: 채팅 Entity 단위 테스트코드 수정

### DIFF
--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatRoomEntity.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatRoomEntity.kt
@@ -23,7 +23,4 @@ class ChatRoomEntity(
     @Column(name = "chat_room_id")
     val id: Long? = null
 
-    fun validateRoomOwner(): Result<Boolean> =
-        Result.success(productEntity.memberEntity != memberEntity)
-
 }

--- a/src/test/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatRoomTest.kt
+++ b/src/test/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatRoomTest.kt
@@ -1,25 +1,23 @@
 package com.challengeteamkotlin.campdaddy.domain.model.chat
 
 import com.challengeteamkotlin.campdaddy.fixture.chat.ChatRoomFixture.chatRoom
-import com.challengeteamkotlin.campdaddy.fixture.chat.ChatRoomFixture.wrongChatRoom
 import com.challengeteamkotlin.campdaddy.fixture.member.MemberFixture.buyer
 import com.challengeteamkotlin.campdaddy.fixture.member.MemberFixture.seller
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 
 class ChatRoomTest : BehaviorSpec({
 
     Given("채팅룸 생성 테스트") {
         When("채팅룸을 만든 멤버가 판매자라면") {
             Then("채팅룸이 생성되지 않는다.") {
-                 runCatching {  wrongChatRoom.validateRoomOwner() }
-                     .isSuccess shouldBe true
+                chatRoom.memberEntity shouldNotBe seller
             }
         }
         When("채팅룸을 만든 멤버가 구매자라면") {
             Then("채팅룸이 생성된다.") {
                 chatRoom.memberEntity shouldBe buyer
-                chatRoom.productEntity.memberEntity shouldBe seller
             }
         }
     }


### PR DESCRIPTION
## 연관 이슈
- closes #37 

## 해당 작업을 추가/변경한 이유는 무엇인가요?
- 채팅방 생성은 구매자만 할 수 있다는 정책 사항에 대한 예외 처리를 비즈니스 로직에서 처리할 것이기 때문에 엔티티 단위 테스트를 수정했습니다.

## 어떤 부분에 리뷰어가 집중하면 좋을까요?
- 엔티티 생성 과정에서 발생하는 예외는 도메인 로직으로 처리하는게 맞는지 아직 좀 헷갈리네요.. 일단 지금은 비즈니스 로직에서 처리하기로 했는데 확실한건 아니라 공부가 더 필요할 것 같습니다

## 리뷰어에게 추가/변경 내용을 상세히 설명해주세요!
- [x] ChatRoomEntity > validateRoomOwner() 메서드 삭제
- [x] ChatRoomTest.kt > 로직 변경
