### PR TITLE
✨ Feat: 채팅 메세지 CRUD 기능 추가 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,6 +94,12 @@ dependencies {
     // .env
     implementation("me.paulschwarz:spring-dotenv:4.0.0")
 
+    // web socket
+    implementation("org.springframework.boot:spring-boot-starter-websocket")
+    implementation("org.webjars:sockjs-client:1.1.2")
+    implementation("org.webjars:stomp-websocket:2.3.3-1")
+
+
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/chat/ChatMessageService.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/chat/ChatMessageService.kt
@@ -1,0 +1,19 @@
+package com.challengeteamkotlin.campdaddy.application.chat
+
+import com.challengeteamkotlin.campdaddy.domain.repository.chat.ChatMessageRepository
+import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.MessageResponse
+import org.springframework.stereotype.Service
+
+@Service
+class ChatMessageService(
+    private val chatMessageRepository: ChatMessageRepository,
+) {
+
+    fun getChatMessages(roomId: Long): List<MessageResponse>? {
+        return chatMessageRepository.findByChatRoomId(roomId)?.map {
+            MessageResponse.from(it)
+        } ?: emptyList()
+    }
+
+    // TODO: 메세지 저장 기능 추후 적용
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/chat/ChatMessageService.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/chat/ChatMessageService.kt
@@ -25,12 +25,7 @@ class ChatMessageService(
         val sender = memberRepository.findByIdOrNull(request.userId) ?: TODO("throw EntityNotFoundException()")
         val chatRoom = chatRoomRepository.findByIdOrNull(roomId) ?: TODO("throw EntityNotFoundException()")
 
-        val message = request.of(
-            message = request.message,
-            member = sender,
-            chatRoom = chatRoom,
-            status = request.status
-        )
+        val message = request.of(sender, chatRoom,)
 
         chatMessageRepository.save(message)
     }

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/chat/ChatMessageService.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/chat/ChatMessageService.kt
@@ -1,11 +1,17 @@
 package com.challengeteamkotlin.campdaddy.application.chat
 
 import com.challengeteamkotlin.campdaddy.domain.repository.chat.ChatMessageRepository
+import com.challengeteamkotlin.campdaddy.domain.repository.chat.ChatRoomRepository
+import com.challengeteamkotlin.campdaddy.domain.repository.member.MemberRepository
+import com.challengeteamkotlin.campdaddy.presentation.chat.dto.request.MessageRequest
 import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.MessageResponse
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 
 @Service
 class ChatMessageService(
+    private val memberRepository: MemberRepository,
+    private val chatRoomRepository: ChatRoomRepository,
     private val chatMessageRepository: ChatMessageRepository,
 ) {
 
@@ -15,5 +21,17 @@ class ChatMessageService(
         } ?: emptyList()
     }
 
-    // TODO: 메세지 저장 기능 추후 적용
+    fun save(roomId: Long, request: MessageRequest) {
+        val sender = memberRepository.findByIdOrNull(request.userId) ?: TODO("throw EntityNotFoundException()")
+        val chatRoom = chatRoomRepository.findByIdOrNull(roomId) ?: TODO("throw EntityNotFoundException()")
+
+        val message = request.of(
+            message = request.message,
+            member = sender,
+            chatRoom = chatRoom,
+            status = request.status
+        )
+
+        chatMessageRepository.save(message)
+    }
 }

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/common/config/chat/StompWebSocketConfig.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/common/config/chat/StompWebSocketConfig.kt
@@ -1,0 +1,31 @@
+package com.challengeteamkotlin.campdaddy.common.config.chat
+
+import com.challengeteamkotlin.campdaddy.common.config.chat.handler.ClientMessageInterceptor
+import org.springframework.context.annotation.Configuration
+import org.springframework.messaging.simp.config.ChannelRegistration
+import org.springframework.messaging.simp.config.MessageBrokerRegistry
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer
+
+@Configuration
+@EnableWebSocketMessageBroker
+class StompWebSocketConfig(
+    private val clientMessageInterceptor: ClientMessageInterceptor,
+) : WebSocketMessageBrokerConfigurer {
+
+    override fun configureMessageBroker(registry: MessageBrokerRegistry) {
+        registry.setApplicationDestinationPrefixes("/pub")
+        registry.enableSimpleBroker("/sub")
+    }
+
+    override fun registerStompEndpoints(registry: StompEndpointRegistry) {
+        registry.addEndpoint("/ws/chat").setAllowedOriginPatterns("*").withSockJS()
+    }
+
+    override fun configureClientInboundChannel(registration: ChannelRegistration) {
+        registration.interceptors(clientMessageInterceptor)
+    }
+
+
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/common/config/chat/handler/ClientMessageInterceptor.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/common/config/chat/handler/ClientMessageInterceptor.kt
@@ -1,0 +1,17 @@
+package com.challengeteamkotlin.campdaddy.common.config.chat.handler
+
+import org.springframework.messaging.Message
+import org.springframework.messaging.MessageChannel
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor
+import org.springframework.messaging.support.ChannelInterceptor
+import org.springframework.stereotype.Component
+
+@Component
+class ClientMessageInterceptor(
+) : ChannelInterceptor {
+    override fun preSend(message: Message<*>, channel: MessageChannel): Message<*>? {
+        val accessor = StompHeaderAccessor.wrap(message)
+        // TODO: 추후 JWT 구현시 수정
+        return message
+    }
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatMessageEntity.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatMessageEntity.kt
@@ -19,6 +19,10 @@ class ChatMessageEntity(
     @JoinColumn(name = "chat_room_id")
     val chatRoom: ChatRoomEntity,
 
+    @Column
+    @Enumerated(EnumType.STRING)
+    val status: MessageStatus
+
     ) : BaseTimeEntity() {
 
     @Id

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatMessageEntity.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatMessageEntity.kt
@@ -13,11 +13,11 @@ class ChatMessageEntity(
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
-    val memberEntity: MemberEntity,
+    val member: MemberEntity,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chat_room_id")
-    val chatRoomEntity: ChatRoomEntity,
+    val chatRoom: ChatRoomEntity,
 
     ) : BaseTimeEntity() {
 

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/MessageStatus.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/MessageStatus.kt
@@ -1,0 +1,5 @@
+package com.challengeteamkotlin.campdaddy.domain.model.chat
+
+enum class MessageStatus {
+    MESSAGE, IMAGE
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/repository/chat/ChatMessageRepository.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/repository/chat/ChatMessageRepository.kt
@@ -1,9 +1,7 @@
 package com.challengeteamkotlin.campdaddy.domain.repository.chat
 
 import com.challengeteamkotlin.campdaddy.infrastructure.hibernate.chat.ChatMessageJpaRepository
-import org.springframework.stereotype.Repository
 
-@Repository
 interface ChatMessageRepository: ChatMessageJpaRepository {
 
 }

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/repository/chat/ChatMessageRepository.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/repository/chat/ChatMessageRepository.kt
@@ -1,0 +1,9 @@
+package com.challengeteamkotlin.campdaddy.domain.repository.chat
+
+import com.challengeteamkotlin.campdaddy.infrastructure.hibernate.chat.ChatMessageJpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface ChatMessageRepository: ChatMessageJpaRepository {
+
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/hibernate/chat/ChatMessageJpaRepository.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/hibernate/chat/ChatMessageJpaRepository.kt
@@ -1,0 +1,10 @@
+package com.challengeteamkotlin.campdaddy.infrastructure.hibernate.chat
+
+import com.challengeteamkotlin.campdaddy.domain.model.chat.ChatMessageEntity
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface ChatMessageJpaRepository : JpaRepository<ChatMessageEntity, Long> {
+    fun findByChatRoomId(roomId: Long): List<ChatMessageEntity>?
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/hibernate/chat/ChatMessageJpaRepository.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/hibernate/chat/ChatMessageJpaRepository.kt
@@ -4,7 +4,6 @@ import com.challengeteamkotlin.campdaddy.domain.model.chat.ChatMessageEntity
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
-@Repository
 interface ChatMessageJpaRepository : JpaRepository<ChatMessageEntity, Long> {
     fun findByChatRoomId(roomId: Long): List<ChatMessageEntity>?
 }

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/ChatMessageController.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/ChatMessageController.kt
@@ -26,7 +26,7 @@ class ChatMessageController(
         @Payload @Valid request: MessageRequest
     ) {
         simpMessageTemplate.convertAndSend("$SUBSCRIBE_DESTINATION$roomId", request)
-        // 메세지 저장 기능 추후 적용
+        chatMessageService.save(roomId, request)
     }
 
     @GetMapping("/chats/{roomId}/messages")

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/ChatMessageController.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/ChatMessageController.kt
@@ -1,0 +1,38 @@
+package com.challengeteamkotlin.campdaddy.presentation.chat
+
+import com.challengeteamkotlin.campdaddy.application.chat.ChatMessageService
+import com.challengeteamkotlin.campdaddy.presentation.chat.dto.request.MessageRequest
+import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.MessageResponse
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.messaging.handler.annotation.DestinationVariable
+import org.springframework.messaging.handler.annotation.MessageMapping
+import org.springframework.messaging.handler.annotation.Payload
+import org.springframework.messaging.simp.SimpMessageSendingOperations
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ChatMessageController(
+    private val chatMessageService: ChatMessageService,
+    private val simpMessageTemplate: SimpMessageSendingOperations
+) {
+    private final val SUBSCRIBE_DESTINATION = "/sub/chat/"
+
+    @MessageMapping("/chat/{roomId}")
+    fun chat(
+        @DestinationVariable roomId: Long,
+        @Payload @Valid request: MessageRequest
+    ) {
+        simpMessageTemplate.convertAndSend("$SUBSCRIBE_DESTINATION$roomId", request)
+        // 메세지 저장 기능 추후 적용
+    }
+
+    @GetMapping("/chats/{roomId}/messages")
+    fun getChatMessages(@PathVariable roomId: Long): ResponseEntity<List<MessageResponse>> {
+        val messages = chatMessageService.getChatMessages(roomId)
+
+        return ResponseEntity.ok().body(messages)
+    }
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/dto/request/MessageRequest.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/dto/request/MessageRequest.kt
@@ -10,7 +10,7 @@ data class MessageRequest(
     val message: String,
     val status: MessageStatus
 ) {
-    fun of(message: String, member: MemberEntity, chatRoom: ChatRoomEntity, status: MessageStatus) =
+    fun of(member: MemberEntity, chatRoom: ChatRoomEntity) =
         ChatMessageEntity(message, member, chatRoom, status)
 
 }

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/dto/request/MessageRequest.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/dto/request/MessageRequest.kt
@@ -2,6 +2,7 @@ package com.challengeteamkotlin.campdaddy.presentation.chat.dto.request
 
 import com.challengeteamkotlin.campdaddy.domain.model.chat.ChatMessageEntity
 import com.challengeteamkotlin.campdaddy.domain.model.chat.ChatRoomEntity
+import com.challengeteamkotlin.campdaddy.domain.model.chat.MessageStatus
 import com.challengeteamkotlin.campdaddy.domain.model.member.MemberEntity
 
 data class MessageRequest(
@@ -9,7 +10,7 @@ data class MessageRequest(
     val message: String,
     val status: MessageStatus
 ) {
-    fun of(message: String, member: MemberEntity, chatRoom: ChatRoomEntity) =
-        ChatMessageEntity(message, member, chatRoom)
+    fun of(message: String, member: MemberEntity, chatRoom: ChatRoomEntity, status: MessageStatus) =
+        ChatMessageEntity(message, member, chatRoom, status)
 
 }

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/dto/request/MessageRequest.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/dto/request/MessageRequest.kt
@@ -1,0 +1,15 @@
+package com.challengeteamkotlin.campdaddy.presentation.chat.dto.request
+
+import com.challengeteamkotlin.campdaddy.domain.model.chat.ChatMessageEntity
+import com.challengeteamkotlin.campdaddy.domain.model.chat.ChatRoomEntity
+import com.challengeteamkotlin.campdaddy.domain.model.member.MemberEntity
+
+data class MessageRequest(
+    val userId: Long,
+    val message: String,
+    val status: MessageStatus
+) {
+    fun of(message: String, member: MemberEntity, chatRoom: ChatRoomEntity) =
+        ChatMessageEntity(message, member, chatRoom)
+
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/dto/request/MessageStatus.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/dto/request/MessageStatus.kt
@@ -1,0 +1,5 @@
+package com.challengeteamkotlin.campdaddy.presentation.chat.dto.request
+
+enum class MessageStatus {
+    MESSAGE, IMAGE
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/dto/request/MessageStatus.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/dto/request/MessageStatus.kt
@@ -1,5 +1,0 @@
-package com.challengeteamkotlin.campdaddy.presentation.chat.dto.request
-
-enum class MessageStatus {
-    MESSAGE, IMAGE
-}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/dto/response/MessageResponse.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/dto/response/MessageResponse.kt
@@ -1,0 +1,18 @@
+package com.challengeteamkotlin.campdaddy.presentation.chat.dto.response
+
+import com.challengeteamkotlin.campdaddy.domain.model.chat.ChatMessageEntity
+import java.time.LocalDateTime
+
+data class MessageResponse(
+    val nickname: String,
+    val message: String,
+    val createdAt: LocalDateTime
+) {
+    companion object {
+        fun from(messageEntity: ChatMessageEntity) = MessageResponse(
+            nickname = messageEntity.member.nickname,
+            message = messageEntity.message,
+            createdAt = messageEntity.createdAt
+        )
+    }
+}

--- a/src/test/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatMessageTest.kt
+++ b/src/test/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatMessageTest.kt
@@ -16,8 +16,8 @@ class ChatMessageTest : BehaviorSpec({
             Then("메세지가 저장된다.") {
                 chat.message shouldBe "빌려주삼"
                 chat.message shouldNotBe ""
-                chat.chatRoomEntity.memberEntity shouldBe buyer
-                chat.memberEntity shouldBe buyer
+                chat.chatRoom.member shouldBe buyer
+                chat.member shouldBe buyer
             }
         }
     }


### PR DESCRIPTION
## 연관 이슈
- closes #45 

## 해당 작업을 추가/변경한 이유는 무엇인가요?
- WebSocket과 STOMP를 활용한 실시간 1:1 채팅을 구현하여, 구매자 / 판매자의 소통을 원할하게 합니다.

## 어떤 부분에 리뷰어가 집중하면 좋을까요?
- WebSocket과 STOMP를 활용한 실시간 1:1 채팅 메세지의 메세지 전송, 채팅방의 메세지 목록을 가져오는 기능을 우선 구현하였습니다.
- JWT 기능 추가시 Interceptor 구현 추가할 예정입니다.

## 리뷰어에게 추가/변경 내용을 상세히 설명해주세요!
- [x] build.gradle.kts webSocket 의존성 추가
- [x] StompWebSocketConfig 생성 및 설정
- [x] [Enum] MessageStatus 생성 및 초기 메세지 상태값 설정
- [x] ClientMessageInterceptor 생성 및 초기 설정
- [x] ChatMessageEntity 프로퍼티명 수정 > 테스트 코드 프로퍼티 명 수정
- [x] [ChatMessage] Controller / Service / Repository 생성
