### PR TITLE
✨ Feat: 예약 CRUD 기능 추가

### DIFF
--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/reservation/ReservationService.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/reservation/ReservationService.kt
@@ -1,0 +1,86 @@
+package com.challengeteamkotlin.campdaddy.application.reservation
+
+import com.challengeteamkotlin.campdaddy.application.reservation.exception.AlreadyReservedDateException
+import com.challengeteamkotlin.campdaddy.application.reservation.exception.ReservationErrorCode
+import com.challengeteamkotlin.campdaddy.application.reservation.exception.StartDateLessThanEndDateException
+import com.challengeteamkotlin.campdaddy.common.exception.EntityNotFoundException
+import com.challengeteamkotlin.campdaddy.domain.model.member.MemberEntity
+import com.challengeteamkotlin.campdaddy.domain.repository.member.MemberRepository
+import com.challengeteamkotlin.campdaddy.domain.repository.product.ProductRepository
+import com.challengeteamkotlin.campdaddy.domain.repository.reservation.ReservationRepository
+import com.challengeteamkotlin.campdaddy.presentation.reservation.dto.reqeust.ReservationCreateRequest
+import com.challengeteamkotlin.campdaddy.presentation.reservation.dto.reqeust.ReservationPatchStatusRequest
+import com.challengeteamkotlin.campdaddy.presentation.reservation.dto.response.ReservationResponse
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+
+@Service
+class ReservationService(
+    private val productRepository: ProductRepository,
+    private val memberRepository: MemberRepository,
+    private val reservationRepository: ReservationRepository
+) {
+
+    @Transactional
+    fun createReservation(reservationCreateRequest: ReservationCreateRequest) {
+        val memberEntity: MemberEntity = memberRepository.findByIdOrNull(reservationCreateRequest.memberId)
+            ?: TODO("throw EntityNotFoundException()")
+        val productEntity = productRepository.findByIdOrNull(reservationCreateRequest.productId)
+            ?: TODO("throw EntityNotFoundException()")
+
+
+
+        if (reservationCreateRequest.startDate > reservationCreateRequest.endDate) {
+            throw StartDateLessThanEndDateException(ReservationErrorCode.START_DATE_LESS_THAN_END_DATE)
+        }
+
+
+        reservationRepository.findFirstByStartDateAndEndDate(
+            reservationCreateRequest.startDate,
+            reservationCreateRequest.endDate
+        )?.run { throw AlreadyReservedDateException(ReservationErrorCode.ALREADY_RESERVED_DATE) }
+
+        val totalPrice = productEntity.pricePerDay *
+                getDateDiff(reservationCreateRequest.startDate, reservationCreateRequest.endDate)
+
+        reservationCreateRequest
+            .toEntity(productEntity, memberEntity, totalPrice)
+            .apply { reservationRepository.save(this) }
+    }
+
+    @Transactional
+    fun patchReservationStatus(reservationPatchStatusRequest: ReservationPatchStatusRequest) {
+        val reservation = reservationRepository.findByIdOrNull(reservationPatchStatusRequest.reservationId!!)
+            ?: throw EntityNotFoundException(ReservationErrorCode.RESERVATION_ENTITY_NOT_FOUND)
+
+        if (reservation.member.id != reservationPatchStatusRequest.memberId
+            && reservation.product.member.id != reservationPatchStatusRequest.memberId
+        ) {
+            throw TODO("throw 권한없음")
+        }
+
+        reservation.reservationStatus = reservationPatchStatusRequest.reservationStatus
+    }
+
+    fun getProductReservations(productId: Long): List<ReservationResponse> =
+        reservationRepository.findByProductId(productId)?.map { ReservationResponse.from(it) }
+            ?: emptyList()
+
+
+    fun getMemberReservations(memberId: Long): List<ReservationResponse> =
+        reservationRepository.findByMemberId(memberId)?.map { ReservationResponse.from(it) }
+            ?: emptyList()
+
+
+    fun getReservation(reservationId: Long): ReservationResponse =
+        reservationRepository.findByIdOrNull(reservationId)
+            ?.let { ReservationResponse.from(it) }
+            ?: throw EntityNotFoundException(ReservationErrorCode.RESERVATION_ENTITY_NOT_FOUND)
+
+    private fun getDateDiff(startDate: LocalDate, endDateTime: LocalDate): Long =
+        ChronoUnit.DAYS.between(startDate, endDateTime)
+
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/reservation/exception/AlreadyReservedDateException.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/reservation/exception/AlreadyReservedDateException.kt
@@ -1,0 +1,7 @@
+package com.challengeteamkotlin.campdaddy.application.reservation.exception
+
+import com.challengeteamkotlin.campdaddy.common.exception.CustomException
+import com.challengeteamkotlin.campdaddy.common.exception.code.ErrorCode
+
+class AlreadyReservedDateException(errorCode: ErrorCode) : CustomException(errorCode) {
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/reservation/exception/ReservationErrorCode.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/reservation/exception/ReservationErrorCode.kt
@@ -1,0 +1,19 @@
+package com.challengeteamkotlin.campdaddy.application.reservation.exception
+
+import com.challengeteamkotlin.campdaddy.common.exception.code.ErrorCode
+import org.springframework.http.HttpStatus
+
+enum class ReservationErrorCode(
+    override val id: Long,
+    override val status: HttpStatus,
+    override val errorMessage: String?
+) : ErrorCode {
+    RESERVATION_ENTITY_NOT_FOUND(4000, HttpStatus.BAD_REQUEST,"예약 데이터를 찾을 수 없습니다."),
+    START_DATE_LESS_THAN_END_DATE(4001, HttpStatus.BAD_REQUEST,"시작 날짜는 종료 날짜보다 뒤 일 수 없습니다."),
+    ALREADY_RESERVED_DATE(4002, HttpStatus.BAD_REQUEST,"이미 예약이 된 날짜입니다.")
+
+
+    ;
+
+    constructor(id: Long, status: HttpStatus) : this(id, status, null)
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/reservation/exception/StartDateLessThanEndDateException.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/reservation/exception/StartDateLessThanEndDateException.kt
@@ -1,0 +1,7 @@
+package com.challengeteamkotlin.campdaddy.application.reservation.exception
+
+import com.challengeteamkotlin.campdaddy.common.exception.CustomException
+import com.challengeteamkotlin.campdaddy.common.exception.code.ErrorCode
+
+class StartDateLessThanEndDateException(errorCode: ErrorCode) : CustomException(errorCode) {
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/model/reservation/ReservationEntity.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/model/reservation/ReservationEntity.kt
@@ -5,31 +5,34 @@ import com.challengeteamkotlin.campdaddy.domain.model.member.MemberEntity
 import com.challengeteamkotlin.campdaddy.domain.model.product.ProductEntity
 import jakarta.persistence.*
 import org.hibernate.annotations.SQLDelete
-import java.time.LocalDateTime
+import java.time.LocalDate
 
 @Entity
 @Table(name = "reservations")
-@SQLDelete(sql = "UPDATE members SET is_deleted = true WHERE id = ?")
+@SQLDelete(sql = "UPDATE reservations SET is_deleted = true WHERE id = ?")
 class ReservationEntity(
     @Column(name = "start_date", nullable = false)
-    val startDate: LocalDateTime,
+    val startDate: LocalDate,
 
     @Column(name = "end_date", nullable = false)
-    val endDate: LocalDateTime,
+    val endDate: LocalDate,
+
+    @Column(name = "total_price", nullable = false)
+    val totalPrice: Long,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id")
-    val product: ProductEntity,
+    var product: ProductEntity,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="member_id")
-    val member: MemberEntity,
+    @JoinColumn(name = "member_id")
+    var member: MemberEntity,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
-    val reservationStatus: ReservationStatus
+    var reservationStatus: ReservationStatus
 
-    ) : BaseEntity() {
+) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "reservation_id")

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/hibernate/reservation/ReservationJpaRepository.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/hibernate/reservation/ReservationJpaRepository.kt
@@ -2,6 +2,20 @@ package com.challengeteamkotlin.campdaddy.infrastructure.hibernate.reservation
 
 import com.challengeteamkotlin.campdaddy.domain.model.reservation.ReservationEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import java.time.LocalDate
 
 interface ReservationJpaRepository : JpaRepository<ReservationEntity, Long> {
+
+    fun findByProductId(productId:Long) :List<ReservationEntity>?
+    fun findByMemberId(memberId:Long) :List<ReservationEntity>?
+
+    @Query(value = "select r " +
+            "from ReservationEntity as r " +
+            "where r.startDate between :startDate and :endDate " +
+            "or r.endDate between :startDate and :endDate " +
+            "or (r.startDate <:startDate  and :endDate < r.endDate )"
+    )
+    fun findFirstByStartDateAndEndDate(startDate: LocalDate, endDate: LocalDate):ReservationEntity?
+
 }

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/reservation/ReservationController.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/reservation/ReservationController.kt
@@ -1,8 +1,8 @@
 package com.challengeteamkotlin.campdaddy.presentation.reservation
 
 import com.challengeteamkotlin.campdaddy.application.reservation.ReservationService
-import com.challengeteamkotlin.campdaddy.presentation.reservation.dto.reqeust.ReservationCreateRequest
-import com.challengeteamkotlin.campdaddy.presentation.reservation.dto.reqeust.ReservationPatchStatusRequest
+import com.challengeteamkotlin.campdaddy.presentation.reservation.dto.reqeust.CreateReservationRequest
+import com.challengeteamkotlin.campdaddy.presentation.reservation.dto.reqeust.PatchReservationStatusRequest
 import com.challengeteamkotlin.campdaddy.presentation.reservation.dto.response.ReservationResponse
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
@@ -17,12 +17,12 @@ class ReservationController(
 
     @PostMapping
     fun createReservation(
-        @RequestBody @Valid reservationCreateRequest: ReservationCreateRequest
+        @RequestBody @Valid createReservationRequest: CreateReservationRequest
     ): ResponseEntity<Unit> {
         // TODO JWT 멤버 아이디
-        reservationCreateRequest.memberId = 1L
+        createReservationRequest.memberId = 1L
 
-        return reservationService.createReservation(reservationCreateRequest)
+        return reservationService.createReservation(createReservationRequest)
             .let {
                 ResponseEntity
                     .status(HttpStatus.CREATED)
@@ -33,10 +33,10 @@ class ReservationController(
     @PatchMapping("/{reservationId}")
     fun patchReservationStatus(
         @PathVariable reservationId: Long,
-        @RequestBody reservationPatchStatusRequest: ReservationPatchStatusRequest
+        @RequestBody patchReservationStatusRequest: PatchReservationStatusRequest
     ): ResponseEntity<Unit> {
-        reservationPatchStatusRequest.reservationId = reservationId
-        return reservationService.patchReservationStatus(reservationPatchStatusRequest)
+        patchReservationStatusRequest.reservationId = reservationId
+        return reservationService.patchReservationStatus(patchReservationStatusRequest)
             .run {
                 ResponseEntity
                     .status(HttpStatus.OK)

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/reservation/ReservationController.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/reservation/ReservationController.kt
@@ -1,0 +1,82 @@
+package com.challengeteamkotlin.campdaddy.presentation.reservation
+
+import com.challengeteamkotlin.campdaddy.application.reservation.ReservationService
+import com.challengeteamkotlin.campdaddy.presentation.reservation.dto.reqeust.ReservationCreateRequest
+import com.challengeteamkotlin.campdaddy.presentation.reservation.dto.reqeust.ReservationPatchStatusRequest
+import com.challengeteamkotlin.campdaddy.presentation.reservation.dto.response.ReservationResponse
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/reservations")
+class ReservationController(
+    private val reservationService: ReservationService
+) {
+
+    @PostMapping
+    fun createReservation(
+        @RequestBody @Valid reservationCreateRequest: ReservationCreateRequest
+    ): ResponseEntity<Unit> {
+        // TODO JWT 멤버 아이디
+        reservationCreateRequest.memberId = 1L
+
+        return reservationService.createReservation(reservationCreateRequest)
+            .let {
+                ResponseEntity
+                    .status(HttpStatus.CREATED)
+                    .build()
+            }
+    }
+
+    @PatchMapping("/{reservationId}")
+    fun patchReservationStatus(
+        @PathVariable reservationId: Long,
+        @RequestBody reservationPatchStatusRequest: ReservationPatchStatusRequest
+    ): ResponseEntity<Unit> {
+        reservationPatchStatusRequest.reservationId = reservationId
+        return reservationService.patchReservationStatus(reservationPatchStatusRequest)
+            .run {
+                ResponseEntity
+                    .status(HttpStatus.OK)
+                    .build()
+            }
+    }
+
+    @GetMapping("/products/{productId}")
+    fun getProductReservations(
+        @PathVariable productId: Long
+    ): ResponseEntity<List<ReservationResponse>> {
+        return reservationService.getProductReservations(productId)
+            .let {
+                ResponseEntity
+                    .status(HttpStatus.OK)
+                    .body(it)
+            }
+    }
+
+    @GetMapping("/members/{memberId}")
+    fun getMemberReservations(
+        @PathVariable memberId: Long
+    ): ResponseEntity<List<ReservationResponse>> {
+        return reservationService.getMemberReservations(memberId)
+            .let {
+                ResponseEntity
+                    .status(HttpStatus.OK)
+                    .body(it)
+            }
+    }
+
+    @GetMapping("/{reservationId}")
+    fun getReservation(
+        @PathVariable reservationId: Long
+    ): ResponseEntity<ReservationResponse> {
+        return reservationService.getReservation(reservationId)
+            .let {
+                ResponseEntity
+                    .status(HttpStatus.OK)
+                    .body(it)
+            }
+    }
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/reservation/dto/reqeust/CreateReservationRequest.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/reservation/dto/reqeust/CreateReservationRequest.kt
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.NotNull
 import org.springframework.format.annotation.DateTimeFormat
 import java.time.LocalDate
 
-data class ReservationCreateRequest(
+data class CreateReservationRequest(
     @NotNull
     val productId: Long,
     @DateTimeFormat(pattern = "yyyy-MM-dd")

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/reservation/dto/reqeust/PatchReservationStatusRequest.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/reservation/dto/reqeust/PatchReservationStatusRequest.kt
@@ -3,7 +3,7 @@ package com.challengeteamkotlin.campdaddy.presentation.reservation.dto.reqeust
 import com.challengeteamkotlin.campdaddy.domain.model.reservation.ReservationStatus
 import com.fasterxml.jackson.annotation.JsonIgnore
 
-data class ReservationPatchStatusRequest(
+data class PatchReservationStatusRequest(
     val reservationStatus: ReservationStatus
 ) {
     @JsonIgnore

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/reservation/dto/reqeust/ReservationCreateRequest.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/reservation/dto/reqeust/ReservationCreateRequest.kt
@@ -1,0 +1,32 @@
+package com.challengeteamkotlin.campdaddy.presentation.reservation.dto.reqeust
+
+import com.challengeteamkotlin.campdaddy.domain.model.member.MemberEntity
+import com.challengeteamkotlin.campdaddy.domain.model.product.ProductEntity
+import com.challengeteamkotlin.campdaddy.domain.model.reservation.ReservationEntity
+import com.challengeteamkotlin.campdaddy.domain.model.reservation.ReservationStatus
+import com.fasterxml.jackson.annotation.JsonIgnore
+import org.jetbrains.annotations.NotNull
+import org.springframework.format.annotation.DateTimeFormat
+import java.time.LocalDate
+
+data class ReservationCreateRequest(
+    @NotNull
+    val productId: Long,
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    val startDate: LocalDate,
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    val endDate: LocalDate,
+) {
+    @JsonIgnore
+    var memberId: Long? = null
+    fun toEntity(productEntity: ProductEntity, memberEntity: MemberEntity, totalPrice: Long): ReservationEntity {
+        return ReservationEntity(
+            startDate = startDate,
+            endDate = endDate,
+            product = productEntity,
+            member = memberEntity,
+            reservationStatus = ReservationStatus.REQ,
+            totalPrice = totalPrice
+        )
+    }
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/reservation/dto/reqeust/ReservationPatchStatusRequest.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/reservation/dto/reqeust/ReservationPatchStatusRequest.kt
@@ -1,0 +1,15 @@
+package com.challengeteamkotlin.campdaddy.presentation.reservation.dto.reqeust
+
+import com.challengeteamkotlin.campdaddy.domain.model.reservation.ReservationStatus
+import com.fasterxml.jackson.annotation.JsonIgnore
+
+data class ReservationPatchStatusRequest(
+    val reservationStatus: ReservationStatus
+) {
+    @JsonIgnore
+    var reservationId: Long? = null
+
+    @JsonIgnore
+    var memberId: Long? = null
+
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/reservation/dto/response/ReservationResponse.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/reservation/dto/response/ReservationResponse.kt
@@ -1,0 +1,26 @@
+package com.challengeteamkotlin.campdaddy.presentation.reservation.dto.response
+
+import com.challengeteamkotlin.campdaddy.domain.model.reservation.ReservationEntity
+import com.challengeteamkotlin.campdaddy.domain.model.reservation.ReservationStatus
+import java.time.LocalDate
+
+data class ReservationResponse(
+    val reservationId: Long,
+    val startDate: LocalDate,
+    val endDate: LocalDate,
+    val productTitle: String,
+    val totalPrice: Long,
+    val reservationStatus: ReservationStatus,
+//  TODO val buyer : MemberResponse
+) {
+    companion object {
+        fun from(reservationEntity: ReservationEntity) = ReservationResponse(
+            reservationId = reservationEntity.id!!,
+            startDate = reservationEntity.startDate,
+            endDate = reservationEntity.endDate,
+            productTitle = reservationEntity.product.title,
+            totalPrice = reservationEntity.totalPrice,
+            reservationStatus = reservationEntity.reservationStatus
+        )
+    }
+}

--- a/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/reservation/ReservationFixture.kt
+++ b/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/reservation/ReservationFixture.kt
@@ -7,10 +7,10 @@ import com.challengeteamkotlin.campdaddy.fixture.product.ProductFixture
 
 object ReservationFixture {
     val wrongDateReservation = ReservationEntity(
-        DateTimeFixture.tomorrow, DateTimeFixture.today, ProductFixture.tent, MemberFixture.buyer, ReservationStatus.REQ
+        DateTimeFixture.tomorrow, DateTimeFixture.today, 10000,ProductFixture.tent, MemberFixture.buyer, ReservationStatus.REQ
     )
 
     val reservation = ReservationEntity(
-        DateTimeFixture.today, DateTimeFixture.tomorrow, ProductFixture.tent, MemberFixture.buyer, ReservationStatus.REQ
+        DateTimeFixture.today, DateTimeFixture.tomorrow, 10000,ProductFixture.tent, MemberFixture.buyer, ReservationStatus.REQ
     )
 }


### PR DESCRIPTION
## 연관 이슈
- closes #47

## 해당 작업을 추가/변경한 이유는 무엇인가요?
- 예약 기능의 CRUD API를 제공합니다.

## 어떤 부분에 리뷰어가 집중하면 좋을까요?
- 다른 도메인의 Exception이 필요한 경우 TODO로 남겨두었습니다.

## 리뷰어에게 추가/변경 내용을 상세히 설명해주세요!
- [x] ReservationEntity의 startDate와 endDate를 LocalDate로 변경 하였습니다.
- [x] ReservationEntity에서 FetchType.LAZY이거나 변경 가능한 프로퍼티를 var로 변경하였습니다.
- [x] 그에 따라 Entity Test Code가 변경 되었습니다.
- [x] 예약 생성, 예약 상태 변경, 상품의 예약 조회, 멤버의 예약 조회, 예약 단건 조회 CRUD 기능을 개발하였습니다.