### PR TITLE
✨ Feat: 채팅방 CRUD 기능 추가

### DIFF
--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/chat/ChatRoomService.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/chat/ChatRoomService.kt
@@ -1,0 +1,74 @@
+package com.challengeteamkotlin.campdaddy.application.chat
+
+import com.challengeteamkotlin.campdaddy.application.chat.exception.ChatErrorCode
+import com.challengeteamkotlin.campdaddy.common.exception.EntityNotFoundException
+import com.challengeteamkotlin.campdaddy.domain.model.chat.ChatRoomEntity
+import com.challengeteamkotlin.campdaddy.domain.repository.chat.ChatMessageRepository
+import com.challengeteamkotlin.campdaddy.domain.repository.chat.ChatRoomRepository
+import com.challengeteamkotlin.campdaddy.domain.repository.member.MemberRepository
+import com.challengeteamkotlin.campdaddy.domain.repository.product.ProductRepository
+import com.challengeteamkotlin.campdaddy.presentation.chat.dto.request.CreateChatRoomRequest
+import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.ChatRoomDetailResponse
+import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.ChatRoomResponse
+import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.MessageResponse
+import jakarta.transaction.Transactional
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+
+@Service
+class ChatRoomService(
+    private val chatRoomRepository: ChatRoomRepository,
+    private val chatMessageRepository: ChatMessageRepository,
+    private val productRepository: ProductRepository,
+    private val memberRepository: MemberRepository,
+) {
+
+    @Transactional
+    fun createChat(request: CreateChatRoomRequest): Long {
+        return when (val chatRoom = chatRoomRepository.findByBuyerIdAndProductId(request.buyerId, request.productId)) {
+            null -> {
+                val buyer = memberRepository.findByIdOrNull(request.buyerId) ?: TODO("throw EntityNotFoundException()")
+                val product =
+                    productRepository.findByIdOrNull(request.productId) ?: TODO("throw EntityNotFoundException()")
+                val chatRoom = request.of(buyer, product.member, product)
+
+                chatRoomRepository.save(chatRoom).id!!
+            }
+
+            else -> chatRoom.id!!
+        }
+    }
+
+    fun getPersonalChatList(memberId: Long): List<ChatRoomResponse>? {
+        val member = memberRepository.findByIdOrNull(memberId) ?: TODO("throw EntityNotFoundException()")
+
+        return chatRoomRepository.findByBuyerIdOrSellerId(member.id!!, member.id!!)?.map {
+            val latestChat = chatMessageRepository.findFirstByChatRoomIdOrderByCreatedAt(it.id!!)
+
+            when (it.buyer) {
+                member -> ChatRoomResponse.of(it.seller, it.product, latestChat)
+                else -> ChatRoomResponse.of(it.buyer, it.product, latestChat)
+            }
+        }
+    }
+
+    fun getChat(roomId: Long): ChatRoomDetailResponse {
+        val chatRoom = chatRoomRepository.findByIdOrNull(roomId) ?: throw EntityNotFoundException(ChatErrorCode.CHAT_NOT_FOUND)
+        val chatMessages = chatMessageRepository.findByChatRoomId(chatRoom.id!!)?.map {
+            MessageResponse.from(it)
+        } ?: emptyList()
+
+        return ChatRoomDetailResponse.of(chatRoom, chatMessages)
+    }
+
+    @Transactional
+    fun removeChat(roomId: Long) {
+        val chatRoom = getChatRoom(roomId)
+
+        chatRoomRepository.delete(chatRoom)
+    }
+
+    private fun getChatRoom(roomId: Long): ChatRoomEntity {
+        return chatRoomRepository.findByIdOrNull(roomId) ?: throw EntityNotFoundException(ChatErrorCode.CHAT_NOT_FOUND)
+    }
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/chat/exception/ChatErrorCode.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/chat/exception/ChatErrorCode.kt
@@ -1,0 +1,14 @@
+package com.challengeteamkotlin.campdaddy.application.chat.exception
+
+import com.challengeteamkotlin.campdaddy.common.exception.code.ErrorCode
+import org.springframework.http.HttpStatus
+
+enum class ChatErrorCode(
+    override val id: Long,
+    override val status: HttpStatus,
+    override val errorMessage: String
+) : ErrorCode {
+    CHAT_NOT_FOUND(2001, HttpStatus.BAD_REQUEST, "채팅방을 찾을 수 없습니다"),
+
+    ;
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatRoomEntity.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatRoomEntity.kt
@@ -9,8 +9,12 @@ import jakarta.persistence.*
 class ChatRoomEntity(
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", insertable = false, updatable = false)
-    val member: MemberEntity,
+    @JoinColumn(name = "buyer_id", insertable = false, updatable = false)
+    val buyer: MemberEntity,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "seller_id", insertable = false, updatable = false)
+    val seller: MemberEntity,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id", insertable = false, updatable = false)

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/hibernate/chat/ChatMessageJpaRepository.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/hibernate/chat/ChatMessageJpaRepository.kt
@@ -2,8 +2,8 @@ package com.challengeteamkotlin.campdaddy.infrastructure.hibernate.chat
 
 import com.challengeteamkotlin.campdaddy.domain.model.chat.ChatMessageEntity
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.stereotype.Repository
 
 interface ChatMessageJpaRepository : JpaRepository<ChatMessageEntity, Long> {
     fun findByChatRoomId(roomId: Long): List<ChatMessageEntity>?
+    fun findFirstByChatRoomIdOrderByCreatedAt(roomId: Long): ChatMessageEntity?
 }

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/hibernate/chat/ChatRoomJpaRepository.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/hibernate/chat/ChatRoomJpaRepository.kt
@@ -4,5 +4,6 @@ import com.challengeteamkotlin.campdaddy.domain.model.chat.ChatRoomEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface ChatRoomJpaRepository: JpaRepository<ChatRoomEntity, Long> {
-    fun findByMemberIdAndProductId(memberId: Long, productId: Long): ChatRoomEntity?
+    fun findByBuyerIdAndProductId(memberId: Long, productId: Long): ChatRoomEntity?
+    fun findByBuyerIdOrSellerId(buyerId: Long, sellerId: Long): List<ChatRoomEntity>?
 }

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/ChatRoomController.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/ChatRoomController.kt
@@ -1,0 +1,43 @@
+package com.challengeteamkotlin.campdaddy.presentation.chat
+
+import com.challengeteamkotlin.campdaddy.application.chat.ChatRoomService
+import com.challengeteamkotlin.campdaddy.presentation.chat.dto.request.CreateChatRoomRequest
+import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.ChatRoomDetailResponse
+import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.ChatRoomResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import java.net.URI
+
+@RestController
+@RequestMapping("/chatroom")
+class ChatRoomController(
+    private val chatRoomService: ChatRoomService
+) {
+    @PostMapping
+    fun createChat(request: CreateChatRoomRequest): ResponseEntity<Unit> {
+        val id = chatRoomService.createChat(request)
+
+        return ResponseEntity.created(URI.create(String.format("/api/v1/chatroom/%d", id))).build()
+    }
+
+    @GetMapping("/me/{memberId}")
+    fun getChatList(@PathVariable memberId: Long): ResponseEntity<List<ChatRoomResponse>> {
+        val chatList = chatRoomService.getPersonalChatList(memberId)
+
+        return ResponseEntity.ok().body(chatList)
+    }
+
+    @GetMapping("/{roomId}")
+    fun getChat(@PathVariable roomId: Long): ResponseEntity<ChatRoomDetailResponse> {
+        val chatList = chatRoomService.getChat(roomId)
+
+        return ResponseEntity.ok().body(chatList)
+    }
+
+    @DeleteMapping("/{roomId}")
+    fun removeChat(@PathVariable roomId: Long): ResponseEntity<Unit> {
+        chatRoomService.removeChat(roomId)
+
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/dto/request/CreateChatRoomRequest.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/dto/request/CreateChatRoomRequest.kt
@@ -1,0 +1,13 @@
+package com.challengeteamkotlin.campdaddy.presentation.chat.dto.request
+
+import com.challengeteamkotlin.campdaddy.domain.model.chat.ChatRoomEntity
+import com.challengeteamkotlin.campdaddy.domain.model.member.MemberEntity
+import com.challengeteamkotlin.campdaddy.domain.model.product.ProductEntity
+
+data class CreateChatRoomRequest(
+    val productId: Long,
+    val buyerId: Long
+) {
+    fun of(buyer: MemberEntity, seller: MemberEntity, productEntity: ProductEntity) =
+        ChatRoomEntity(buyer, seller, productEntity)
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/dto/response/ChatRoomDetailResponse.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/dto/response/ChatRoomDetailResponse.kt
@@ -1,0 +1,16 @@
+package com.challengeteamkotlin.campdaddy.presentation.chat.dto.response
+
+import com.challengeteamkotlin.campdaddy.domain.model.chat.ChatRoomEntity
+import com.challengeteamkotlin.campdaddy.presentation.product.dto.response.ProductDetailResponse
+
+data class ChatRoomDetailResponse(
+    val productDetail: ProductDetailResponse,
+    val chatHistory: List<MessageResponse>,
+) {
+    companion object {
+        fun of(chatRoom: ChatRoomEntity, chatHistory: List<MessageResponse>) = ChatRoomDetailResponse(
+            productDetail = ProductDetailResponse.from(chatRoom.product),
+            chatHistory = chatHistory
+        )
+    }
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/dto/response/ChatRoomResponse.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/dto/response/ChatRoomResponse.kt
@@ -1,0 +1,23 @@
+package com.challengeteamkotlin.campdaddy.presentation.chat.dto.response
+
+import com.challengeteamkotlin.campdaddy.domain.model.chat.ChatMessageEntity
+import com.challengeteamkotlin.campdaddy.domain.model.member.MemberEntity
+import com.challengeteamkotlin.campdaddy.domain.model.product.ProductEntity
+import java.time.LocalDateTime
+
+data class ChatRoomResponse(
+    val nickname: String,
+    val productImageUrl: String?,
+    val lastChatMessage: String?,
+    val lastChatDate: LocalDateTime?,
+) {
+    companion object {
+        fun of(member: MemberEntity, product: ProductEntity, message: ChatMessageEntity?) =
+            ChatRoomResponse(
+                nickname = member.nickname,
+                productImageUrl = product.images[0]?.imageUrl,
+                lastChatMessage = message?.message,
+                lastChatDate = message?.createdAt
+            )
+    }
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/product/dto/response/ProductDetailResponse.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/product/dto/response/ProductDetailResponse.kt
@@ -1,0 +1,19 @@
+package com.challengeteamkotlin.campdaddy.presentation.product.dto.response
+
+import com.challengeteamkotlin.campdaddy.domain.model.product.ProductEntity
+
+data class ProductDetailResponse(
+    val title: String,
+    val images: String,
+    val content: String,
+    val pricePerDay: Long,
+) {
+    companion object {
+        fun from(productEntity: ProductEntity) = ProductDetailResponse(
+            productEntity.title,
+            productEntity.images[0].imageUrl,
+            productEntity.content,
+            productEntity.pricePerDay
+        )
+    }
+}

--- a/src/test/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatMessageTest.kt
+++ b/src/test/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatMessageTest.kt
@@ -11,12 +11,12 @@ class ChatMessageTest : BehaviorSpec({
     Given("채팅 메시지 생성 테스트") {
 
         When("새로운 메세지가 생성될 때 공백이 아니면") {
-            var chat = ChatMessageEntity("빌려주삼", buyer, chatRoom)
+            var chat = ChatMessageEntity("빌려주삼", buyer, chatRoom, MessageStatus.MESSAGE)
 
             Then("메세지가 저장된다.") {
                 chat.message shouldBe "빌려주삼"
                 chat.message shouldNotBe ""
-                chat.chatRoom.member shouldBe buyer
+                chat.chatRoom.buyer shouldBe buyer
                 chat.member shouldBe buyer
             }
         }

--- a/src/test/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatRoomTest.kt
+++ b/src/test/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatRoomTest.kt
@@ -12,12 +12,12 @@ class ChatRoomTest : BehaviorSpec({
     Given("채팅룸 생성 테스트") {
         When("채팅룸을 만든 멤버가 판매자라면") {
             Then("채팅룸이 생성되지 않는다.") {
-                chatRoom.member shouldNotBe seller
+                chatRoom.buyer shouldNotBe seller
             }
         }
         When("채팅룸을 만든 멤버가 구매자라면") {
             Then("채팅룸이 생성된다.") {
-                chatRoom.member shouldBe buyer
+                chatRoom.buyer shouldBe buyer
             }
         }
     }

--- a/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/chat/ChatRoomFixture.kt
+++ b/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/chat/ChatRoomFixture.kt
@@ -6,6 +6,5 @@ import com.challengeteamkotlin.campdaddy.fixture.member.MemberFixture.seller
 import com.challengeteamkotlin.campdaddy.fixture.product.ProductFixture.tent
 
 object ChatRoomFixture {
-    val chatRoom = ChatRoomEntity(buyer, tent)
-    val wrongChatRoom = ChatRoomEntity(seller, tent)
+    val chatRoom = ChatRoomEntity(buyer = buyer, seller = seller, product = tent)
 }


### PR DESCRIPTION
## 연관 이슈
- closes #50 

## 해당 작업을 추가/변경한 이유는 무엇인가요?
- 채팅방의 CRUD를 구현하였습니다.

## 어떤 부분에 리뷰어가 집중하면 좋을까요?
- Controller의 URI가 매핑이 어색하다고 느끼는데, 수정할게 있을까요?
- Service의 비즈니스 로직이 어색한 부분이 있을까요?

## 리뷰어에게 추가/변경 내용을 상세히 설명해주세요!
- [x] 채팅방 내부 상품 컴포넌트 노출을 위한 ProductDetailResponse 생성
- [x] ChatMessageJpaRepository 마지막 채팅 메세지 조회 메서드 생성
- [x] 채팅방 CRUD 구현
- [x] ChatRoomEntity 엔티티 수정 -> Buyer만 가지는 연관관계에서 Seller, Buyer 둘 다 가지는 연관관계로 확장
- [x] ChatRoomFixture 필요없는 fixture 삭제

