### PR TITLE
✨ Feat: 예약 CRUD 기능 추가

### DIFF
--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/reservation/ReservationService.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/reservation/ReservationService.kt
@@ -1,0 +1,103 @@
+package com.challengeteamkotlin.campdaddy.application.reservation
+
+import com.challengeteamkotlin.campdaddy.application.reservation.exception.AlreadyReservedDateException
+import com.challengeteamkotlin.campdaddy.application.reservation.exception.ReservationErrorCode
+import com.challengeteamkotlin.campdaddy.application.reservation.exception.StartDateLessThanEndDateException
+import com.challengeteamkotlin.campdaddy.common.exception.EntityNotFoundException
+import com.challengeteamkotlin.campdaddy.domain.model.member.MemberEntity
+import com.challengeteamkotlin.campdaddy.domain.repository.member.MemberRepository
+import com.challengeteamkotlin.campdaddy.domain.repository.product.ProductRepository
+import com.challengeteamkotlin.campdaddy.domain.repository.reservation.ReservationRepository
+import com.challengeteamkotlin.campdaddy.presentation.reservation.dto.reqeust.CreateReservationRequest
+import com.challengeteamkotlin.campdaddy.presentation.reservation.dto.reqeust.PatchReservationStatusRequest
+import com.challengeteamkotlin.campdaddy.presentation.reservation.dto.response.ReservationResponse
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+
+@Service
+class ReservationService(
+    private val productRepository: ProductRepository,
+    private val memberRepository: MemberRepository,
+    private val reservationRepository: ReservationRepository
+) {
+
+    @Transactional
+    fun createReservation(createReservationRequest: CreateReservationRequest) {
+        val memberEntity: MemberEntity = memberRepository.findByIdOrNull(createReservationRequest.memberId)
+            ?: TODO("throw EntityNotFoundException()")
+        val productEntity = productRepository.findByIdOrNull(createReservationRequest.productId)
+            ?: TODO("throw EntityNotFoundException()")
+
+        if (createReservationRequest.startDate lessThan createReservationRequest.endDate) {
+            throw StartDateLessThanEndDateException(ReservationErrorCode.START_DATE_LESS_THAN_END_DATE)
+        }
+
+        if (checkAlreadyReserved(
+                createReservationRequest.productId, createReservationRequest.startDate, createReservationRequest.endDate
+            )
+        ) throw AlreadyReservedDateException(ReservationErrorCode.ALREADY_RESERVED_DATE)
+
+
+        val totalPrice = productEntity.pricePerDay *
+                getDateDiff(createReservationRequest.startDate, createReservationRequest.endDate)
+
+        createReservationRequest
+            .toEntity(productEntity, memberEntity, totalPrice)
+            .apply { reservationRepository.save(this) }
+    }
+
+    @Transactional
+    fun patchReservationStatus(patchReservationStatusRequest: PatchReservationStatusRequest) {
+        val reservation = reservationRepository.findByIdOrNull(patchReservationStatusRequest.reservationId!!)
+            ?: throw EntityNotFoundException(ReservationErrorCode.RESERVATION_ENTITY_NOT_FOUND)
+
+        if (reservation.member.id != patchReservationStatusRequest.memberId
+            && reservation.product.member.id != patchReservationStatusRequest.memberId
+        ) {
+            throw TODO("throw 권한없음")
+        }
+
+        reservation.reservationStatus = patchReservationStatusRequest.reservationStatus
+    }
+
+    @Transactional(readOnly = true)
+    fun getProductReservations(productId: Long): List<ReservationResponse> =
+        reservationRepository.findByProductId(productId)?.map { ReservationResponse.from(it) }
+            ?: emptyList()
+
+
+    @Transactional(readOnly = true)
+    fun getMemberReservations(memberId: Long): List<ReservationResponse> =
+        reservationRepository.findByMemberId(memberId)?.map { ReservationResponse.from(it) }
+            ?: emptyList()
+
+
+    @Transactional(readOnly = true)
+    fun getReservation(reservationId: Long): ReservationResponse =
+        reservationRepository.findByIdOrNull(reservationId)
+            ?.let {
+                ReservationResponse.from(it)
+            } ?: throw EntityNotFoundException(ReservationErrorCode.RESERVATION_ENTITY_NOT_FOUND)
+
+
+    private fun getDateDiff(startDate: LocalDate, endDate: LocalDate): Long {
+        val dateDiff = ChronoUnit.DAYS.between(startDate, endDate)
+        return if(dateDiff == 0L) 1 else dateDiff
+    }
+
+    private fun checkAlreadyReserved(productId: Long, startDate: LocalDate, endDate: LocalDate): Boolean {
+        return reservationRepository.findFirstByProductIdAndStartDateAndEndDate(
+            productId,
+            startDate,
+            endDate
+        )?.let { true } ?: false
+    }
+
+    private infix fun LocalDate.lessThan(anotherDate: LocalDate): Boolean {
+        return this > anotherDate
+    }
+
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/reservation/ReservationService.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/reservation/ReservationService.kt
@@ -2,7 +2,7 @@ package com.challengeteamkotlin.campdaddy.application.reservation
 
 import com.challengeteamkotlin.campdaddy.application.reservation.exception.AlreadyReservedDateException
 import com.challengeteamkotlin.campdaddy.application.reservation.exception.ReservationErrorCode
-import com.challengeteamkotlin.campdaddy.application.reservation.exception.StartDateLessThanEndDateException
+import com.challengeteamkotlin.campdaddy.application.reservation.exception.EndDateLessThanStartDateException
 import com.challengeteamkotlin.campdaddy.common.exception.EntityNotFoundException
 import com.challengeteamkotlin.campdaddy.domain.model.member.MemberEntity
 import com.challengeteamkotlin.campdaddy.domain.repository.member.MemberRepository
@@ -31,8 +31,9 @@ class ReservationService(
         val productEntity = productRepository.findByIdOrNull(createReservationRequest.productId)
             ?: TODO("throw EntityNotFoundException()")
 
-        if (createReservationRequest.startDate lessThan createReservationRequest.endDate) {
-            throw StartDateLessThanEndDateException(ReservationErrorCode.START_DATE_LESS_THAN_END_DATE)
+
+        if (createReservationRequest.endDate lessThan createReservationRequest.startDate) {
+            throw EndDateLessThanStartDateException(ReservationErrorCode.END_DATE_LESS_THAN_START_DATE)
         }
 
         if (checkAlreadyReserved(
@@ -97,7 +98,7 @@ class ReservationService(
     }
 
     private infix fun LocalDate.lessThan(anotherDate: LocalDate): Boolean {
-        return this > anotherDate
+        return this < anotherDate
     }
 
 }

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/reservation/ReservationService.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/reservation/ReservationService.kt
@@ -45,7 +45,7 @@ class ReservationService(
                 getDateDiff(createReservationRequest.startDate, createReservationRequest.endDate)
 
         createReservationRequest
-            .toEntity(productEntity, memberEntity, totalPrice)
+            .of(productEntity, memberEntity, totalPrice)
             .apply { reservationRepository.save(this) }
     }
 

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/reservation/exception/AlreadyReservedDateException.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/reservation/exception/AlreadyReservedDateException.kt
@@ -1,0 +1,7 @@
+package com.challengeteamkotlin.campdaddy.application.reservation.exception
+
+import com.challengeteamkotlin.campdaddy.common.exception.CustomException
+import com.challengeteamkotlin.campdaddy.common.exception.code.ErrorCode
+
+class AlreadyReservedDateException(errorCode: ErrorCode) : CustomException(errorCode) {
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/reservation/exception/EndDateLessThanStartDateException.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/reservation/exception/EndDateLessThanStartDateException.kt
@@ -3,5 +3,5 @@ package com.challengeteamkotlin.campdaddy.application.reservation.exception
 import com.challengeteamkotlin.campdaddy.common.exception.CustomException
 import com.challengeteamkotlin.campdaddy.common.exception.code.ErrorCode
 
-class StartDateLessThanEndDateException(errorCode: ErrorCode) : CustomException(errorCode) {
+class EndDateLessThanStartDateException(errorCode: ErrorCode) : CustomException(errorCode) {
 }

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/reservation/exception/ReservationErrorCode.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/reservation/exception/ReservationErrorCode.kt
@@ -9,7 +9,7 @@ enum class ReservationErrorCode(
     override val errorMessage: String?
 ) : ErrorCode {
     RESERVATION_ENTITY_NOT_FOUND(4000, HttpStatus.BAD_REQUEST, "예약 데이터를 찾을 수 없습니다."),
-    START_DATE_LESS_THAN_END_DATE(4001, HttpStatus.BAD_REQUEST, "시작 날짜는 종료 날짜보다 뒤 일 수 없습니다."),
+    END_DATE_LESS_THAN_START_DATE(4001, HttpStatus.BAD_REQUEST, "종료 날짜는 시작 날짜보다 작을 수 없습니다."),
     ALREADY_RESERVED_DATE(4002, HttpStatus.BAD_REQUEST, "이미 예약이 된 날짜입니다.")
 
 

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/reservation/exception/ReservationErrorCode.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/reservation/exception/ReservationErrorCode.kt
@@ -1,0 +1,19 @@
+package com.challengeteamkotlin.campdaddy.application.reservation.exception
+
+import com.challengeteamkotlin.campdaddy.common.exception.code.ErrorCode
+import org.springframework.http.HttpStatus
+
+enum class ReservationErrorCode(
+    override val id: Long,
+    override val status: HttpStatus,
+    override val errorMessage: String?
+) : ErrorCode {
+    RESERVATION_ENTITY_NOT_FOUND(4000, HttpStatus.BAD_REQUEST, "예약 데이터를 찾을 수 없습니다."),
+    START_DATE_LESS_THAN_END_DATE(4001, HttpStatus.BAD_REQUEST, "시작 날짜는 종료 날짜보다 뒤 일 수 없습니다."),
+    ALREADY_RESERVED_DATE(4002, HttpStatus.BAD_REQUEST, "이미 예약이 된 날짜입니다.")
+
+
+    ;
+
+    constructor(id: Long, status: HttpStatus) : this(id, status, null)
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/reservation/exception/StartDateLessThanEndDateException.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/reservation/exception/StartDateLessThanEndDateException.kt
@@ -1,0 +1,7 @@
+package com.challengeteamkotlin.campdaddy.application.reservation.exception
+
+import com.challengeteamkotlin.campdaddy.common.exception.CustomException
+import com.challengeteamkotlin.campdaddy.common.exception.code.ErrorCode
+
+class StartDateLessThanEndDateException(errorCode: ErrorCode) : CustomException(errorCode) {
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/model/reservation/ReservationEntity.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/model/reservation/ReservationEntity.kt
@@ -5,31 +5,34 @@ import com.challengeteamkotlin.campdaddy.domain.model.member.MemberEntity
 import com.challengeteamkotlin.campdaddy.domain.model.product.ProductEntity
 import jakarta.persistence.*
 import org.hibernate.annotations.SQLDelete
-import java.time.LocalDateTime
+import java.time.LocalDate
 
 @Entity
 @Table(name = "reservations")
-@SQLDelete(sql = "UPDATE members SET is_deleted = true WHERE id = ?")
+@SQLDelete(sql = "UPDATE reservations SET is_deleted = true WHERE id = ?")
 class ReservationEntity(
     @Column(name = "start_date", nullable = false)
-    val startDate: LocalDateTime,
+    val startDate: LocalDate,
 
     @Column(name = "end_date", nullable = false)
-    val endDate: LocalDateTime,
+    val endDate: LocalDate,
+
+    @Column(name = "total_price", nullable = false)
+    val totalPrice: Long,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id")
     val product: ProductEntity,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="member_id")
+    @JoinColumn(name = "member_id")
     val member: MemberEntity,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
-    val reservationStatus: ReservationStatus
+    var reservationStatus: ReservationStatus
 
-    ) : BaseEntity() {
+) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "reservation_id")

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/hibernate/reservation/ReservationJpaRepository.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/hibernate/reservation/ReservationJpaRepository.kt
@@ -2,6 +2,21 @@ package com.challengeteamkotlin.campdaddy.infrastructure.hibernate.reservation
 
 import com.challengeteamkotlin.campdaddy.domain.model.reservation.ReservationEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import java.time.LocalDate
 
 interface ReservationJpaRepository : JpaRepository<ReservationEntity, Long> {
+
+    fun findByProductId(productId:Long) :List<ReservationEntity>?
+    fun findByMemberId(memberId:Long) :List<ReservationEntity>?
+
+    @Query(value = "select r " +
+            "from ReservationEntity as r " +
+            "where r.product.id = :productId " +
+            "and r.startDate between :startDate and :endDate " +
+            "or r.endDate between :startDate and :endDate " +
+            "or (r.startDate <:startDate  and :endDate < r.endDate )"
+    )
+    fun findFirstByProductIdAndStartDateAndEndDate(productId: Long, startDate: LocalDate, endDate: LocalDate):ReservationEntity?
+
 }

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/reservation/ReservationController.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/reservation/ReservationController.kt
@@ -1,0 +1,82 @@
+package com.challengeteamkotlin.campdaddy.presentation.reservation
+
+import com.challengeteamkotlin.campdaddy.application.reservation.ReservationService
+import com.challengeteamkotlin.campdaddy.presentation.reservation.dto.reqeust.CreateReservationRequest
+import com.challengeteamkotlin.campdaddy.presentation.reservation.dto.reqeust.PatchReservationStatusRequest
+import com.challengeteamkotlin.campdaddy.presentation.reservation.dto.response.ReservationResponse
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/reservations")
+class ReservationController(
+    private val reservationService: ReservationService
+) {
+
+    @PostMapping
+    fun createReservation(
+        @RequestBody @Valid createReservationRequest: CreateReservationRequest
+    ): ResponseEntity<Unit> {
+        // TODO JWT 멤버 아이디
+        createReservationRequest.memberId = 1L
+
+        return reservationService.createReservation(createReservationRequest)
+            .let {
+                ResponseEntity
+                    .status(HttpStatus.CREATED)
+                    .build()
+            }
+    }
+
+    @PatchMapping("/{reservationId}")
+    fun patchReservationStatus(
+        @PathVariable reservationId: Long,
+        @RequestBody patchReservationStatusRequest: PatchReservationStatusRequest
+    ): ResponseEntity<Unit> {
+        patchReservationStatusRequest.reservationId = reservationId
+        return reservationService.patchReservationStatus(patchReservationStatusRequest)
+            .run {
+                ResponseEntity
+                    .status(HttpStatus.OK)
+                    .build()
+            }
+    }
+
+    @GetMapping("/products/{productId}")
+    fun getProductReservations(
+        @PathVariable productId: Long
+    ): ResponseEntity<List<ReservationResponse>> {
+        return reservationService.getProductReservations(productId)
+            .let {
+                ResponseEntity
+                    .status(HttpStatus.OK)
+                    .body(it)
+            }
+    }
+
+    @GetMapping("/members/{memberId}")
+    fun getMemberReservations(
+        @PathVariable memberId: Long
+    ): ResponseEntity<List<ReservationResponse>> {
+        return reservationService.getMemberReservations(memberId)
+            .let {
+                ResponseEntity
+                    .status(HttpStatus.OK)
+                    .body(it)
+            }
+    }
+
+    @GetMapping("/{reservationId}")
+    fun getReservation(
+        @PathVariable reservationId: Long
+    ): ResponseEntity<ReservationResponse> {
+        return reservationService.getReservation(reservationId)
+            .let {
+                ResponseEntity
+                    .status(HttpStatus.OK)
+                    .body(it)
+            }
+    }
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/reservation/dto/reqeust/CreateReservationRequest.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/reservation/dto/reqeust/CreateReservationRequest.kt
@@ -19,7 +19,7 @@ data class CreateReservationRequest(
 ) {
     @JsonIgnore
     var memberId: Long? = null
-    fun toEntity(productEntity: ProductEntity, memberEntity: MemberEntity, totalPrice: Long): ReservationEntity {
+    fun of(productEntity: ProductEntity, memberEntity: MemberEntity, totalPrice: Long): ReservationEntity {
         return ReservationEntity(
             startDate = startDate,
             endDate = endDate,

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/reservation/dto/reqeust/CreateReservationRequest.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/reservation/dto/reqeust/CreateReservationRequest.kt
@@ -1,0 +1,32 @@
+package com.challengeteamkotlin.campdaddy.presentation.reservation.dto.reqeust
+
+import com.challengeteamkotlin.campdaddy.domain.model.member.MemberEntity
+import com.challengeteamkotlin.campdaddy.domain.model.product.ProductEntity
+import com.challengeteamkotlin.campdaddy.domain.model.reservation.ReservationEntity
+import com.challengeteamkotlin.campdaddy.domain.model.reservation.ReservationStatus
+import com.fasterxml.jackson.annotation.JsonIgnore
+import org.jetbrains.annotations.NotNull
+import org.springframework.format.annotation.DateTimeFormat
+import java.time.LocalDate
+
+data class CreateReservationRequest(
+    @NotNull
+    val productId: Long,
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    val startDate: LocalDate,
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    val endDate: LocalDate,
+) {
+    @JsonIgnore
+    var memberId: Long? = null
+    fun toEntity(productEntity: ProductEntity, memberEntity: MemberEntity, totalPrice: Long): ReservationEntity {
+        return ReservationEntity(
+            startDate = startDate,
+            endDate = endDate,
+            product = productEntity,
+            member = memberEntity,
+            reservationStatus = ReservationStatus.REQ,
+            totalPrice = totalPrice
+        )
+    }
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/reservation/dto/reqeust/PatchReservationStatusRequest.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/reservation/dto/reqeust/PatchReservationStatusRequest.kt
@@ -1,0 +1,15 @@
+package com.challengeteamkotlin.campdaddy.presentation.reservation.dto.reqeust
+
+import com.challengeteamkotlin.campdaddy.domain.model.reservation.ReservationStatus
+import com.fasterxml.jackson.annotation.JsonIgnore
+
+data class PatchReservationStatusRequest(
+    val reservationStatus: ReservationStatus
+) {
+    @JsonIgnore
+    var reservationId: Long? = null
+
+    @JsonIgnore
+    var memberId: Long? = null
+
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/reservation/dto/response/ReservationResponse.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/reservation/dto/response/ReservationResponse.kt
@@ -1,0 +1,30 @@
+package com.challengeteamkotlin.campdaddy.presentation.reservation.dto.response
+
+import com.challengeteamkotlin.campdaddy.domain.model.reservation.ReservationEntity
+import com.challengeteamkotlin.campdaddy.domain.model.reservation.ReservationStatus
+import java.time.LocalDate
+
+data class ReservationResponse(
+    val reservationId: Long,
+    val startDate: LocalDate,
+    val endDate: LocalDate,
+    val productTitle: String,
+    val totalPrice: Long,
+    val reservationStatus: ReservationStatus,
+    val memberId: Long,
+    val memberName: String,
+
+) {
+    companion object {
+        fun from(reservationEntity: ReservationEntity) = ReservationResponse(
+            reservationId = reservationEntity.id!!,
+            startDate = reservationEntity.startDate,
+            endDate = reservationEntity.endDate,
+            productTitle = reservationEntity.product.title,
+            totalPrice = reservationEntity.totalPrice,
+            reservationStatus = reservationEntity.reservationStatus,
+            memberId = reservationEntity.member.id!!,
+            memberName = reservationEntity.member.name
+        )
+    }
+}

--- a/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/reservation/DateTimeFixture.kt
+++ b/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/reservation/DateTimeFixture.kt
@@ -1,8 +1,8 @@
 package com.challengeteamkotlin.campdaddy.fixture.reservation
 
-import java.time.LocalDateTime
+import java.time.LocalDate
 
 object DateTimeFixture {
-    val today: LocalDateTime = LocalDateTime.now()
-    val tomorrow: LocalDateTime = LocalDateTime.now().plusDays(1)
+    val today: LocalDate = LocalDate.now()
+    val tomorrow: LocalDate = LocalDate.now().plusDays(1)
 }

--- a/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/reservation/ReservationFixture.kt
+++ b/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/reservation/ReservationFixture.kt
@@ -7,10 +7,20 @@ import com.challengeteamkotlin.campdaddy.fixture.product.ProductFixture
 
 object ReservationFixture {
     val wrongDateReservation = ReservationEntity(
-        DateTimeFixture.tomorrow, DateTimeFixture.today, ProductFixture.tent, MemberFixture.buyer, ReservationStatus.REQ
+        DateTimeFixture.tomorrow,
+        DateTimeFixture.today,
+        10000,
+        ProductFixture.tent,
+        MemberFixture.buyer,
+        ReservationStatus.REQ
     )
 
     val reservation = ReservationEntity(
-        DateTimeFixture.today, DateTimeFixture.tomorrow, ProductFixture.tent, MemberFixture.buyer, ReservationStatus.REQ
+        DateTimeFixture.today,
+        DateTimeFixture.tomorrow,
+        10000,
+        ProductFixture.tent,
+        MemberFixture.buyer,
+        ReservationStatus.REQ
     )
 }


### PR DESCRIPTION
## 연관 이슈
- closes #51

## 해당 작업을 추가/변경한 이유는 무엇인가요?
- 예약 CRUD 기능 추가

## 어떤 부분에 리뷰어가 집중하면 좋을까요?
- 로직에서 리팩토링이 가능한 부분이 있는지 확인해주세요.
- 정책 상 추가 되어야 할 예외가 더 있는지 확인해주세요

## 리뷰어에게 추가/변경 내용을 상세히 설명해주세요!
- [x] ReservationEntity의 startDate와 endDate를 LocalDate로 변경.
- [x] ReservationEntity에서 update 되는 프로퍼티를 var로 변경.
- [x] 그에 따라 Entity Test Code가 변경 되었습니다.
- [x] 예약 생성, 예약 상태 변경, 상품의 예약 조회, 멤버의 예약 조회, 예약 단건 조회 CRUD 기능을 개발하였습니다.
- [x] lazy init exception 해결 (@Transactional(readOnly = true))
