### PR TITLE
♻️ Refactor: 채팅 도메인 기능 리팩토링 적용

### DIFF
--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/chat/ChatMessageService.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/chat/ChatMessageService.kt
@@ -25,7 +25,7 @@ class ChatMessageService(
         val chatRoom = chatRoomRepository.findByIdOrNull(roomId) ?: throw EntityNotFoundException(CommonErrorCode.ID_NOT_FOUND)
 
         if (chatRoom.buyer != sender && chatRoom.seller != sender) {
-            throw throw ChatFailureException(ChatErrorCode.ACCESS_DENIED)
+            throw ChatFailureException(ChatErrorCode.ACCESS_DENIED)
         }
 
         val message = request.of(sender, chatRoom)

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/chat/ChatMessageService.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/chat/ChatMessageService.kt
@@ -1,10 +1,14 @@
 package com.challengeteamkotlin.campdaddy.application.chat
 
+import com.challengeteamkotlin.campdaddy.application.chat.exception.ChatErrorCode
+import com.challengeteamkotlin.campdaddy.application.chat.exception.ChatFailureException
+import com.challengeteamkotlin.campdaddy.common.exception.EntityNotFoundException
+import com.challengeteamkotlin.campdaddy.common.exception.code.CommonErrorCode
 import com.challengeteamkotlin.campdaddy.domain.repository.chat.ChatMessageRepository
 import com.challengeteamkotlin.campdaddy.domain.repository.chat.ChatRoomRepository
 import com.challengeteamkotlin.campdaddy.domain.repository.member.MemberRepository
 import com.challengeteamkotlin.campdaddy.presentation.chat.dto.request.MessageRequest
-import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.MessageResponse
+import jakarta.transaction.Transactional
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 
@@ -15,18 +19,20 @@ class ChatMessageService(
     private val chatMessageRepository: ChatMessageRepository,
 ) {
 
-    fun getChatMessages(roomId: Long): List<MessageResponse>? {
-        return chatMessageRepository.findByChatRoomId(roomId)?.map {
-            MessageResponse.from(it)
-        } ?: emptyList()
-    }
+    @Transactional
+    fun save(roomId: Long, request: MessageRequest): Long {
+        val sender = memberRepository.findByIdOrNull(request.userId) ?: throw EntityNotFoundException(CommonErrorCode.ID_NOT_FOUND)
+        val chatRoom = chatRoomRepository.findByIdOrNull(roomId) ?: throw EntityNotFoundException(CommonErrorCode.ID_NOT_FOUND)
 
-    fun save(roomId: Long, request: MessageRequest) {
-        val sender = memberRepository.findByIdOrNull(request.userId) ?: TODO("throw EntityNotFoundException()")
-        val chatRoom = chatRoomRepository.findByIdOrNull(roomId) ?: TODO("throw EntityNotFoundException()")
+        if (chatRoom.buyer != sender && chatRoom.seller != sender) {
+            throw throw ChatFailureException(ChatErrorCode.ACCESS_DENIED)
+        }
 
-        val message = request.of(sender, chatRoom,)
+        val message = request.of(sender, chatRoom)
 
         chatMessageRepository.save(message)
+
+        return message.id!!
     }
+
 }

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/chat/exception/ChatErrorCode.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/chat/exception/ChatErrorCode.kt
@@ -9,6 +9,6 @@ enum class ChatErrorCode(
     override val errorMessage: String
 ) : ErrorCode {
     CHAT_NOT_FOUND(2001, HttpStatus.BAD_REQUEST, "채팅방을 찾을 수 없습니다"),
-
+    ACCESS_DENIED(2002, HttpStatus.BAD_REQUEST, "채팅방에 존재하지 않는 회원은 메세지를 보낼 수 없습니다")
     ;
 }

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/chat/exception/ChatFailureException.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/chat/exception/ChatFailureException.kt
@@ -1,0 +1,7 @@
+package com.challengeteamkotlin.campdaddy.application.chat.exception
+
+import com.challengeteamkotlin.campdaddy.common.exception.CustomException
+import com.challengeteamkotlin.campdaddy.common.exception.code.ErrorCode
+
+class ChatFailureException(errorCode: ErrorCode): CustomException(errorCode){
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/ChatMessageController.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/ChatMessageController.kt
@@ -2,21 +2,17 @@ package com.challengeteamkotlin.campdaddy.presentation.chat
 
 import com.challengeteamkotlin.campdaddy.application.chat.ChatMessageService
 import com.challengeteamkotlin.campdaddy.presentation.chat.dto.request.MessageRequest
-import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.MessageResponse
 import jakarta.validation.Valid
-import org.springframework.http.ResponseEntity
 import org.springframework.messaging.handler.annotation.DestinationVariable
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.messaging.handler.annotation.Payload
 import org.springframework.messaging.simp.SimpMessageSendingOperations
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class ChatMessageController(
     private val chatMessageService: ChatMessageService,
-    private val simpMessageTemplate: SimpMessageSendingOperations
+    private val simpMessageTemplate: SimpMessageSendingOperations,
 ) {
     private final val SUBSCRIBE_DESTINATION = "/sub/chat/"
 
@@ -29,10 +25,4 @@ class ChatMessageController(
         chatMessageService.save(roomId, request)
     }
 
-    @GetMapping("/chats/{roomId}/messages")
-    fun getChatMessages(@PathVariable roomId: Long): ResponseEntity<List<MessageResponse>> {
-        val messages = chatMessageService.getChatMessages(roomId)
-
-        return ResponseEntity.ok().body(messages)
-    }
 }

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/ChatRoomController.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/ChatRoomController.kt
@@ -14,7 +14,7 @@ class ChatRoomController(
     private val chatRoomService: ChatRoomService
 ) {
     @PostMapping
-    fun createChat(request: CreateChatRoomRequest): ResponseEntity<Unit> {
+    fun createChat(@RequestBody request: CreateChatRoomRequest): ResponseEntity<Unit> {
         val id = chatRoomService.createChat(request)
 
         return ResponseEntity.created(URI.create(String.format("/api/v1/chatroom/%d", id))).build()


### PR DESCRIPTION
## 연관 이슈
- closes #60 

## 해당 작업을 추가/변경한 이유는 무엇인가요?
- 채팅 메세지 조회 메서드가 [ChatMessage, ChatRoom] Service에서 중복으로 존재한다는 것을 발견하였고, 채팅 메세지는 채팅방 안에서 조회하는 경우가 일반적이기에 이 책임을 ChatRoomService로 통합시켰습니다.
- 채팅 메세지가 저장되기 전, 메세지를 보내는 주체가 채팅방에 속하지 않은 멤버일 때 접근 권한을 주지 않는 비즈니스 로직을 추가하였고, 이와 관련된 Exception 클래스를 새로 생성하였습니다.
- ChatRoomService 메서드 중 createChat()에 @RequestBody를 추가하였습니다.

## 어떤 부분에 리뷰어가 집중하면 좋을까요?
- 이 외에도 변경하면 좋을 코드가 있다면 알려주세요! 

## 리뷰어에게 추가/변경 내용을 상세히 설명해주세요!
- [x] ChatFailureException 생성
  - [x] ChatErrorCode 내 ACCESS_DENIED 에러코드 추가
- [x] ChatRoomController > createChat @RequestBody 누락 추가
- [x] ChatMessageController / ChatMessageService Get 메서드 삭제 -> ChatRoomService 통합
- [x] ChatMessageService > save 메서드 접근 권한 비즈니스 로직 추가
