### PR TITLE
✅ Test: 채팅 메세지, 채팅방 Service 단위 테스트코드 추가 

### DIFF
--- a/src/test/kotlin/com/challengeteamkotlin/campdaddy/application/chat/ChatMessageServiceTest.kt
+++ b/src/test/kotlin/com/challengeteamkotlin/campdaddy/application/chat/ChatMessageServiceTest.kt
@@ -1,0 +1,36 @@
+package com.challengeteamkotlin.campdaddy.application.chat
+
+import com.challengeteamkotlin.campdaddy.application.chat.exception.ChatErrorCode
+import com.challengeteamkotlin.campdaddy.application.chat.exception.ChatFailureException
+import com.challengeteamkotlin.campdaddy.fixture.chat.ChatMessageFixture.messageRequestForFail
+import com.challengeteamkotlin.campdaddy.fixture.chat.ChatMessageFixture.messageRequestForPass
+import com.challengeteamkotlin.campdaddy.fixture.chat.ChatRoomFixture.existChatRoomId
+import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+
+class ChatMessageServiceTest(
+    private val chatMessageService: ChatMessageService = mockk(),
+) : BehaviorSpec({
+
+    Given("채팅 메세지 저장 테스트") {
+        When("채팅 메세지를 보내는 멤버가 채팅방에 속한 멤버가 아니면") {
+            every { chatMessageService.save(existChatRoomId, messageRequestForFail) } throws ChatFailureException(ChatErrorCode.ACCESS_DENIED)
+
+            Then("예외가 발생한다.") {
+                val exception = shouldThrowExactly<ChatFailureException> { chatMessageService.save(existChatRoomId, messageRequestForFail) }
+
+                exception.errorCode shouldBe ChatErrorCode.ACCESS_DENIED
+            }
+        }
+        When("채팅 메세지를 보내는 멤버가 채팅방에 속한 멤버라면") {
+            every { chatMessageService.save(existChatRoomId, messageRequestForPass) } returns 1L
+            Then("채팅 메세지를 저장한다.") {
+                val idForCreatedMessage = chatMessageService.save(existChatRoomId, messageRequestForPass)
+                idForCreatedMessage shouldBe 1L
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/challengeteamkotlin/campdaddy/application/chat/ChatRoomServiceTest.kt
+++ b/src/test/kotlin/com/challengeteamkotlin/campdaddy/application/chat/ChatRoomServiceTest.kt
@@ -1,0 +1,119 @@
+package com.challengeteamkotlin.campdaddy.application.chat
+
+import com.challengeteamkotlin.campdaddy.application.chat.exception.ChatErrorCode
+import com.challengeteamkotlin.campdaddy.common.exception.EntityNotFoundException
+import com.challengeteamkotlin.campdaddy.domain.repository.chat.ChatMessageRepository
+import com.challengeteamkotlin.campdaddy.fixture.chat.ChatMessageFixture.chatMessageResponse
+import com.challengeteamkotlin.campdaddy.fixture.chat.ChatRoomFixture.chatRoomResponse
+import com.challengeteamkotlin.campdaddy.fixture.chat.ChatRoomFixture.createChatRoomRequest
+import com.challengeteamkotlin.campdaddy.fixture.chat.ChatRoomFixture.createdChatRoomId
+import com.challengeteamkotlin.campdaddy.fixture.chat.ChatRoomFixture.existChatRoomId
+import com.challengeteamkotlin.campdaddy.fixture.chat.ChatRoomFixture.personalChatRoomResponse
+import com.challengeteamkotlin.campdaddy.fixture.chat.ChatRoomFixture.wrongChatRoomId
+import com.challengeteamkotlin.campdaddy.fixture.member.MemberFixture.memberId
+import com.challengeteamkotlin.campdaddy.fixture.product.ProductFixture.productDetail
+import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+
+class ChatRoomServiceTest(
+    private val chatRoomService: ChatRoomService = mockk(),
+    private val chatMessageRepository: ChatMessageRepository = mockk(),
+) : BehaviorSpec({
+
+    Given("채팅방 생성 테스트") {
+
+        When("멤버와 상품이 있다는 가정하에 채팅방이 이미 생성되어 있으면") {
+            every { chatRoomService.createChat(any()) } returns existChatRoomId
+            val chatRoomId = chatRoomService.createChat(createChatRoomRequest)
+
+            Then("해당 채팅방의 아이디를 리턴한다.") {
+                chatRoomId shouldBe existChatRoomId
+            }
+        }
+
+        When("멤버와 상품이 있다는 가정하에 채팅방이 존재하지 않으면") {
+            every { chatRoomService.createChat(createChatRoomRequest) } returns createdChatRoomId
+            val newChatRoomId = chatRoomService.createChat(createChatRoomRequest)
+
+            Then("새로운 채팅방을 만들고, 아이디를 리턴한다.") {
+                newChatRoomId shouldBe createdChatRoomId
+            }
+        }
+    }
+
+    Given("멤버 개인 채팅방 리스트 조회 테스트") {
+
+        When("유저의 ID로 조회되는 채팅방이 없으면") {
+            every { chatRoomService.getPersonalChatList(memberId) } returns emptyList()
+
+            Then("빈 리스트를 리턴한다.") {
+                val emptyList = chatRoomService.getPersonalChatList(memberId)
+                emptyList shouldBe emptyList()
+            }
+        }
+
+        When("유저의 ID로 조회되는 채팅방이 있으면") {
+            every { chatRoomService.getPersonalChatList(memberId) } returns personalChatRoomResponse
+            val personalChatRoomResponse = chatRoomService.getPersonalChatList(memberId)
+
+            Then("상대방 닉네임, 상품 이미지, 마지막 메세지, 마지막 메세지의 날짜 정보를 가진 채팅방 리스트를 리턴한다.") {
+                personalChatRoomResponse?.map {
+                    it shouldNotBe null
+                }
+            }
+        }
+    }
+
+    Given("채팅방 조회 테스트") {
+
+        When("채팅방 ID로 조회할 때 채팅방이 존재하면") {
+            every { chatRoomService.getChat(any()) } returns chatRoomResponse
+            val existChatRoomResponse =  chatRoomService.getChat(existChatRoomId)
+            Then("채팅방의 메세지, 상품 정보와 함께 방을 리턴한다.") {
+                existChatRoomResponse.chatHistory shouldBe chatMessageResponse
+                existChatRoomResponse.productDetail shouldBe productDetail
+            }
+        }
+
+        When("채팅방 ID로 조회할 때 채팅방이 존재하지 않으면") {
+            every { chatRoomService.getChat(wrongChatRoomId) } throws EntityNotFoundException(ChatErrorCode.CHAT_NOT_FOUND)
+
+            Then("예외가 던져진다.") {
+                val exception = shouldThrowExactly<EntityNotFoundException> { chatRoomService.getChat(wrongChatRoomId) }
+
+                exception.errorCode shouldBe ChatErrorCode.CHAT_NOT_FOUND
+            }
+        }
+    }
+
+    Given("채팅방 삭제 테스트") {
+
+        When("채팅방 ID로 삭제를 시도할 때 채팅방이 존재하면") {
+            every { chatRoomService.removeChat(existChatRoomId) } just runs
+            every { chatRoomService.getChat(existChatRoomId) } throws EntityNotFoundException(ChatErrorCode.CHAT_NOT_FOUND)
+            every { chatMessageRepository.findByChatRoomId(existChatRoomId) } returns emptyList()
+            Then("해당 채팅방과 안에 담긴 메세지는 모두 삭제되고, 재조회는 되지 않는다") {
+                val emptyChatHistory = chatMessageRepository.findByChatRoomId(existChatRoomId)
+                val exception = shouldThrowExactly<EntityNotFoundException> { chatRoomService.getChat(existChatRoomId) }
+
+                exception.errorCode shouldBe ChatErrorCode.CHAT_NOT_FOUND
+
+                emptyChatHistory shouldBe emptyList()
+            }
+        }
+        When("채팅방 ID로 삭제를 시도할 때 채팅방이 존재하지 않으면") {
+            every { chatRoomService.getChat(wrongChatRoomId) } throws EntityNotFoundException(ChatErrorCode.CHAT_NOT_FOUND)
+            Then("예외가 던져진다.") {
+                val exception = shouldThrowExactly<EntityNotFoundException> { chatRoomService.getChat(wrongChatRoomId) }
+
+                exception.errorCode shouldBe ChatErrorCode.CHAT_NOT_FOUND
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/challengeteamkotlin/campdaddy/domain/model/member/MemberEntityTest.kt
+++ b/src/test/kotlin/com/challengeteamkotlin/campdaddy/domain/model/member/MemberEntityTest.kt
@@ -1,6 +1,6 @@
 package com.challengeteamkotlin.campdaddy.domain.model.member
 
-import com.challengeteamkotlin.campdaddy.fixture.member.MemberEntityFixture.testPerson
+import com.challengeteamkotlin.campdaddy.fixture.member.MemberFixture.testPerson
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 

--- a/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/chat/ChatMessageFixture.kt
+++ b/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/chat/ChatMessageFixture.kt
@@ -1,4 +1,25 @@
 package com.challengeteamkotlin.campdaddy.fixture.chat
 
+import com.challengeteamkotlin.campdaddy.domain.model.chat.MessageStatus
+import com.challengeteamkotlin.campdaddy.fixture.member.MemberFixture.memberId
+import com.challengeteamkotlin.campdaddy.fixture.member.MemberFixture.wrongMemberId
+import com.challengeteamkotlin.campdaddy.presentation.chat.dto.request.MessageRequest
+import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.MessageResponse
+import java.time.LocalDateTime
+
 object ChatMessageFixture {
+    // Request
+    val messageRequestForPass = MessageRequest(wrongMemberId, "안녕하세요", MessageStatus.MESSAGE)
+    val messageRequestForFail = MessageRequest(memberId, "안녕하세요", MessageStatus.MESSAGE)
+
+    // Response
+    val messageResponseFirst = MessageResponse("unknown", "빌리고 싶습니다", LocalDateTime.now())
+    val messageResponseSecond = MessageResponse("unknown", "빌리고 싶습니다", LocalDateTime.now())
+    val messageResponseThird = MessageResponse("unknown", "빌리고 싶습니다", LocalDateTime.now())
+
+    val chatMessageResponse = listOf(
+        messageResponseFirst,
+        messageResponseSecond,
+        messageResponseThird
+    )
 }

--- a/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/chat/ChatRoomFixture.kt
+++ b/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/chat/ChatRoomFixture.kt
@@ -1,10 +1,46 @@
 package com.challengeteamkotlin.campdaddy.fixture.chat
 
 import com.challengeteamkotlin.campdaddy.domain.model.chat.ChatRoomEntity
+import com.challengeteamkotlin.campdaddy.fixture.chat.ChatMessageFixture.chatMessageResponse
 import com.challengeteamkotlin.campdaddy.fixture.member.MemberFixture.buyer
 import com.challengeteamkotlin.campdaddy.fixture.member.MemberFixture.seller
+import com.challengeteamkotlin.campdaddy.fixture.product.ProductFixture.productDetail
 import com.challengeteamkotlin.campdaddy.fixture.product.ProductFixture.tent
+import com.challengeteamkotlin.campdaddy.presentation.chat.dto.request.CreateChatRoomRequest
+import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.ChatRoomDetailResponse
+import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.ChatRoomResponse
+import java.time.LocalDateTime
 
 object ChatRoomFixture {
+    // ID
+    val existChatRoomId = 1L
+    val createdChatRoomId = 1L
+    val wrongChatRoomId = 999L
+
+    // Request
+    val createChatRoomRequest = CreateChatRoomRequest(productId = 1, buyerId = 1)
+
+    // Response
+    val personalChatRoomResponseOfFirst =
+        ChatRoomResponse("unknown", "http://localhgst:8080/image/blah.png", "구매 하시나요?", LocalDateTime.now())
+
+    val personalChatRoomResponseOfSecond =
+        ChatRoomResponse("unknown", "http://localhgst:8080/image/blah.png", "구매 하시나요?", LocalDateTime.now())
+
+    val personalChatRoomResponseOfThird =
+        ChatRoomResponse("unknown", "http://localhgst:8080/image/blah.png", "구매 하시나요?", LocalDateTime.now())
+
+    val personalChatRoomResponse: List<ChatRoomResponse> = listOf(
+        personalChatRoomResponseOfFirst,
+        personalChatRoomResponseOfSecond,
+        personalChatRoomResponseOfThird
+    )
+
+    val chatRoomResponse = ChatRoomDetailResponse(
+        productDetail = productDetail,
+        chatHistory = chatMessageResponse
+    )
+
+    // Entity
     val chatRoom = ChatRoomEntity(buyer = buyer, seller = seller, product = tent)
 }

--- a/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/member/MemberEntityFixture.kt
+++ b/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/member/MemberEntityFixture.kt
@@ -1,9 +1,0 @@
-package com.challengeteamkotlin.campdaddy.fixture.member
-
-import com.challengeteamkotlin.campdaddy.domain.model.member.MemberEntity
-import com.challengeteamkotlin.campdaddy.domain.model.member.MemberProvider
-
-object MemberEntityFixture {
-    val testPerson = MemberEntity("test@kakao.com","test", "test", "010-1234-1234", MemberProvider.KAKAO, "1234test")
-
-}

--- a/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/member/MemberFixture.kt
+++ b/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/member/MemberFixture.kt
@@ -3,8 +3,11 @@ package com.challengeteamkotlin.campdaddy.fixture.member
 import com.challengeteamkotlin.campdaddy.domain.model.member.MemberEntity
 import com.challengeteamkotlin.campdaddy.domain.model.member.MemberProvider
 
-
 object MemberFixture {
+    val testPerson = MemberEntity("test@kakao.com", "test", "test", "010-1234-1234", MemberProvider.KAKAO, "1234test")
     val buyer = MemberEntity("buyer@google.com", "buyer", "백다삼", "01012345678", MemberProvider.KAKAO, "1234test")
     val seller = MemberEntity("seller@google.com", "seller", "김다팜", "01087654321", MemberProvider.KAKAO, "1234test")
+
+    const val memberId = 1L
+    const val wrongMemberId = 999L
 }

--- a/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/product/ProductFixture.kt
+++ b/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/product/ProductFixture.kt
@@ -3,10 +3,19 @@ package com.challengeteamkotlin.campdaddy.fixture.product
 import com.challengeteamkotlin.campdaddy.domain.model.product.Category
 import com.challengeteamkotlin.campdaddy.domain.model.product.ProductEntity
 import com.challengeteamkotlin.campdaddy.fixture.member.MemberFixture.seller
+import com.challengeteamkotlin.campdaddy.presentation.product.dto.response.ProductDetailResponse
 
 object ProductFixture {
+    // Entity
     val lamp = ProductEntity(seller, 20000, "불이 잘 들어오는 램프", "잘 들어 옵니다.", Category.LAMPS)
     val tent = ProductEntity(seller, 100_000, "텐트 빌려드려요", "텐트 빌려드림ㅇㅇ", Category.TENTS)
     val tent1 = ProductEntity(seller, 100_000, "군대 A형 텐트", "군대에서 전역할때 훔쳐온 A형 텐트입니다.", Category.TENTS)
 
+    // Response
+    val productDetail = ProductDetailResponse(
+        title = tent.title,
+        images = "http://localhost:8080/images/blah.png",
+        content = tent.content,
+        pricePerDay = 100_000
+    )
 }


### PR DESCRIPTION
## 연관 이슈
- closes #59 

## 해당 작업을 추가/변경한 이유는 무엇인가요?
- 채팅 메세지와 채팅방 비즈니스 로직에 대한 테스트코드를 작성하여 비즈니스 로직이 변경 되었을 때, 정책에서 벗어나지 않는지 쉽게 추적할 수 있습니다.

## 어떤 부분에 리뷰어가 집중하면 좋을까요?
- 서비스 클래스에 대한 단위 테스트 코드를 작성할 때, 서비스의 메서드만을 검증해야 하는지, 의존하고 있는 클래스를 mocking하여 작성해야 하는지 아직 감이 잘 안잡히네요 제가 생각한 것은 아래와 같아요

  1. 서비스 메서드만 검증 했을 때
     - 의존되는 클래스들은 항상 정상적으로 작동이 될 것이라는 가정하에 서비스의 로직만 쉽게 파악할 수 있다.(명세의 목적이 확실해짐)
     - 의존되는 클래스들에 대한 단위 테스트를 추가적으로 작성하여 테스트 커버리지를 높힌다.
  2. 의존하고 있는 클래스를 mocking 했을 때
     - 서비스 단위 테스트에서 의존되는 클래스의 메서드를 함께 검증하면 연관관계가 어떻게 되는지 파악할 수 있어 더욱 확실하게 비즈니스 로직을 작성할 수 있다.

"단위" 테스트의 경계가 어디까지인지 모호한데, 어떻게 생각하시나요

## 리뷰어에게 추가/변경 내용을 상세히 설명해주세요!
- [x]  ChatMessageService 단위 테스트 코드 추가
  - [x]  채팅 메세지 저장 기능
- [x]  ChatRoomService 단위 테스트 코드 추가
  - [x]  채팅방 생성 기능
  - [x]  채팅방 조회 기능 (MemberId)
  - [x]  채팅방 조회 기능 (RoomId)
  - [x]  채팅방 삭제 기능 (RoomId)
- [x]  MemberEntityFixture 삭제 > MemberEntity 통합
- [x]  Fixture 프로퍼티 추가

