### PR TITLE
✨ Feat: Github Actions을 활용한 프로젝트 CD 기능 추가

### DIFF
--- a/.github/workflows/camp-daddy-cd.yml
+++ b/.github/workflows/camp-daddy-cd.yml
@@ -1,18 +1,15 @@
-name: Camp Daddy CI
+name: Camp Daddy CD
 
 on:
-  pull_request:
-    branches: [ main, dev ]
+  push:
+    branches:
+      - main
+      - dev
 
 jobs:
-  test:
+  deploy:
     name: 우분투 설치
     runs-on: ubuntu-latest
-
-    permissions:
-      pull-requests: write
-      checks: write
-      contents: read
 
     steps:
       - name: 레포지토리 체크아웃
@@ -40,24 +37,38 @@ jobs:
           java-version: '17'
           distribution: 'corretto'
 
+
       - name: Gradle 권한 부여
         run: chmod +x gradlew
 
       - name: Gradle 빌드 & 테스트 실행
         run: ./gradlew build test
 
-      - name: 테스트 결과 PR 등록
-        uses: EnricoMi/publish-unit-test-result-action@v1
-        if: ${{ always() }}
+      - name: Docker 빌드 & 푸쉬
+        run: |
+          docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+          docker build -f Dockerfile -t ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}
+          docker push ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}
+
+      - name: EC2 배포
+        uses: appleboy/ssh-action@master
         with:
-          files: '**/build/test-results/test/TEST-*.xml'
+          host: ${{ secrets.AWS_HOST }}
+          username: $ {{ secrets.AWS_USERNAME }}
+          key: ${{ secrets.AWS_SSH_KEY }}
+          script: |
+            sudo docker ps
+            sudo docker pull ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}
+            sudo docker run -d -p ${{ secrets.SERVER_PORT }}:${{ secrets.SERVER_PORT }} ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}
+            sudo docker image prune -f
 
       - name: 슬랙 Alarm 전송
         uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
-          author_name: CI 결과 알림
+          author_name: CD 결과 알림
           fields: message, commit, author, ref, workflow, took
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         if: always()
+            

--- a/.github/workflows/camp-daddy-cd.yml
+++ b/.github/workflows/camp-daddy-cd.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Docker 빌드 & 푸쉬
         run: |
           docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
-          docker build -f Dockerfile -t ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}
+          docker build -f Dockerfile -t ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }} .
           docker push ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}
 
       - name: EC2 배포

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM openjdk:17
+
+ARG JAR_FILE=*.jar
+COPY /build/libs/$JAR_FILE camp-daddy-server.jar
+
+LABEL authors="mussangdeul"
+
+ENTRYPOINT ["java", "-Djava.security.egd=file:/dev/./urandom", "-jar", "camp-daddy-server.jar"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,8 +101,8 @@ dependencies {
     implementation("org.webjars:sockjs-client:1.1.2")
     implementation("org.webjars:stomp-websocket:2.3.3-1")
 
-
 }
+
 
 tasks.withType<KotlinCompile> {
 	kotlinOptions {
@@ -113,4 +113,9 @@ tasks.withType<KotlinCompile> {
 
 tasks.withType<Test> {
 	useJUnitPlatform()
+}
+
+// plain.jar 생성 방지
+tasks.getByName<Jar>("jar") {
+    enabled = false
 }


### PR DESCRIPTION
## 연관 이슈
- closes #68 

## 해당 작업을 추가/변경한 이유는 무엇인가요?
- 지속적인 배포를 위해 Github Actions + Docker, AWS EC2를 활용하였습니다.
- 최종 배포 전, 모든 단위 테스트를 실행하여 PR Merge 이후, main, dev 브랜치로 최종 Push 될 때까지 안정된 서비스임을 확인할 수 있으며, 지속적으로 배포를 하여 코드 변경 시, 서버를 재시작하는 과정을 자동화 했습니다.

## 어떤 부분에 리뷰어가 집중하면 좋을까요?
- 위 작업을 통해서 배포를 하기 전, 한 번 더 테스트를 검증하여 서비스 배포에 불안한 부분이 없는지 파악하고자 합니다.
- 테스트가 실패할 때는 배포하지 않는 로직이 추가되어야 할 것 같다고 생각했는데, 사실 gradlew에서 build & test가 실패하면 다음 step으로 넘어가지 않기 때문에 따로 추가는 하지 않았습니다.

## 리뷰어에게 추가/변경 내용을 상세히 설명해주세요!
- [x] CD 플로우
  1. 레포지토리로 체크아웃 합니다.
  2. .env 파일을 생성하고 Secrets에 등록된 값을 주입합니다.
  3.  Gradle 캐싱을 적용합니다.(빌드 속도 향상을 위함)
  4. JDK 17버전을 설치합니다.
  5. gradlew 파일에 권한을 부여하고, 프로젝트 파일을 빌드 및 테스트합니다.
  6. Docker Repository에 성공적으로 빌드된 파일을 Push합니다.
  7. EC2에 원격 접속하여 Docker Repository에서 빌드 파일을 Pull하고, 실행합니다.
  8. 슬랙에 알림봇을 통해 CD 결과를 공유합니다.
- [x] CD 파일 추가(Github Actions 적용)
- [x] plain.jar 생성 방지를 위한 build.gradle.kts 수정
- [x] CI 플로우 gradle 캐시 추가
