### PR TITLE
🐛 Bugfix: 채팅 Interceptor 헤더 설정 버그 파악 및 해결

### DIFF
--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/common/config/chat/handler/ClientMessageInterceptor.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/common/config/chat/handler/ClientMessageInterceptor.kt
@@ -18,7 +18,7 @@ class ClientMessageInterceptor(
         val accessor = StompHeaderAccessor.wrap(message)
 
         if (accessor.command == StompCommand.CONNECT) {
-            val accessToken = accessor.getFirstNativeHeader("Bearer") as String
+            val accessToken = accessor.getFirstNativeHeader("Authorization") as String
             jwtPlugin.validateToken(accessToken)
                 .onFailure { throw AccessDeniedException(AuthErrorCode.ACCESS_DENIED) }
         }


### PR DESCRIPTION
## 연관 이슈
- closes #96 

## 해당 작업을 추가/변경한 이유는 무엇인가요?
- ClientMessageInterceptor에서 Header를 잘못된 값으로 받아오고 있어 이를 수정하였습니다.

## 어떤 부분에 리뷰어가 집중하면 좋을까요?
- X

## 리뷰어에게 추가/변경 내용을 상세히 설명해주세요!
- [x] Header 값 변경(Bearer -> Authorization)
