### PR TITLE
🐛 Bugfix: ChatRoomEntity 연관관계 ID Insert 버그 파악 및 해결

### DIFF
--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatRoomEntity.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/ChatRoomEntity.kt
@@ -9,15 +9,15 @@ import jakarta.persistence.*
 class ChatRoomEntity(
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "buyer_id", insertable = false, updatable = false)
+    @JoinColumn(name = "buyer_id", updatable = false)
     val buyer: MemberEntity,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "seller_id", insertable = false, updatable = false)
+    @JoinColumn(name = "seller_id", updatable = false)
     val seller: MemberEntity,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "product_id", insertable = false, updatable = false)
+    @JoinColumn(name = "product_id", updatable = false)
     val product: ProductEntity,
 
     ) {


### PR DESCRIPTION
## 연관 이슈
- closes #102 

## 해당 작업을 추가/변경한 이유는 무엇인가요?
- 채팅방이 생성될 때 연관 엔티티들의 ID 값이 DB에 INSERT 되지 않아 이를 수정했습니다.

## 어떤 부분에 리뷰어가 집중하면 좋을까요?
- X

## 리뷰어에게 추가/변경 내용을 상세히 설명해주세요!
- [x] 연관 관계 insertable 옵션 삭제
