### PR TITLE
🐛 Bugfix: 채팅방 > 채팅 메세지 > 닉네임 조회 시 LazyInitializationException 버그 파악 및 해결

### DIFF
--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/chat/ChatRoomService.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/chat/ChatRoomService.kt
@@ -13,9 +13,9 @@ import com.challengeteamkotlin.campdaddy.presentation.chat.dto.request.CreateCha
 import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.ChatRoomDetailResponse
 import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.ChatRoomResponse
 import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.MessageResponse
-import jakarta.transaction.Transactional
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class ChatRoomService(
@@ -36,6 +36,7 @@ class ChatRoomService(
         }
     }
 
+    @Transactional(readOnly = true)
     fun getPersonalChatList(memberId: Long): List<ChatRoomResponse>? {
         val member = memberRepository.getMemberByIdOrNull(memberId) ?: throw EntityNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND)
 
@@ -49,6 +50,7 @@ class ChatRoomService(
         } ?: emptyList()
     }
 
+    @Transactional(readOnly = true)
     fun getChatDetail(roomId: Long): ChatRoomDetailResponse {
         val chatRoom = getChatRoom(roomId)
         val chatMessages = chatMessageRepository.getChatMessageByChatRoomId(chatRoom.id!!)?.map {


### PR DESCRIPTION
## 연관 이슈
- closes #110 

## 해당 작업을 추가/변경한 이유는 무엇인가요?
- 연관 관계 중 FetchType이 Lazy로 적용되어있어 이를 조회할 때 LazyInitializationException이 발생하였습니다. 그 중 하나의 해결 방법으로 @Transaction에 옵션으로 `readOnly = true`를 적용했습니다.

## 어떤 부분에 리뷰어가 집중하면 좋을까요?
- 비슷한 상황을 겪고 계시면 같은 방법으로 해결하시면 될 것 같습니다. 아니면 QueryDSL로 전환하셔도 무방할 듯! 

## 리뷰어에게 추가/변경 내용을 상세히 설명해주세요!
- [x] @Transactional(readOnly = true) 적용 
