### PR TITLE
🐛 Bugfix: 소셜 로그인 email 검증 로직 버그 파악 및 해결

### DIFF
--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/auth/SocialMemberService.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/auth/SocialMemberService.kt
@@ -1,7 +1,5 @@
 package com.challengeteamkotlin.campdaddy.application.auth
 
-import com.challengeteamkotlin.campdaddy.application.auth.exception.AuthErrorCode
-import com.challengeteamkotlin.campdaddy.application.auth.exception.DuplicateEmailException
 import com.challengeteamkotlin.campdaddy.domain.model.member.MemberEntity
 import com.challengeteamkotlin.campdaddy.domain.model.member.OAuth2Provider
 import com.challengeteamkotlin.campdaddy.domain.repository.member.MemberRepository
@@ -15,8 +13,6 @@ class SocialMemberService(
 
     fun registerIfAbsent(userInfo: OAuth2UserInfo): MemberEntity {
         val provider = OAuth2Provider.valueOf(userInfo.provider)
-        val existEmail = memberRepository.existMemberByEmail(userInfo.email)
-        if (existEmail) throw DuplicateEmailException(AuthErrorCode.DUPLICATE_EMAIL)
         return if (memberRepository.existMemberByProviderAndProviderId(provider, userInfo.id)) {
             memberRepository.findMemberByProviderAndProviderId(provider, userInfo.id)
         } else {

--- a/src/test/kotlin/com/challengeteamkotlin/campdaddy/application/auth/SocialMemberServiceTest.kt
+++ b/src/test/kotlin/com/challengeteamkotlin/campdaddy/application/auth/SocialMemberServiceTest.kt
@@ -1,15 +1,11 @@
 package com.challengeteamkotlin.campdaddy.application.auth
 
-import com.challengeteamkotlin.campdaddy.application.auth.exception.DuplicateEmailException
 import com.challengeteamkotlin.campdaddy.domain.model.member.OAuth2Provider
 import com.challengeteamkotlin.campdaddy.domain.repository.member.MemberRepository
 import com.challengeteamkotlin.campdaddy.fixture.auth.AuthFixture.existAuthInfo
-import com.challengeteamkotlin.campdaddy.fixture.auth.AuthFixture.newAuthInfo
 import com.challengeteamkotlin.campdaddy.fixture.auth.AuthFixture.oAuth2KakaoUserInfo
-import com.challengeteamkotlin.campdaddy.fixture.member.MemberEntityFixture.existEmailMember
 import com.challengeteamkotlin.campdaddy.fixture.member.MemberEntityFixture.existMember
 import com.challengeteamkotlin.campdaddy.fixture.member.MemberEntityFixture.kakaoNewMember
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.extensions.spring.SpringExtension
 import io.kotest.matchers.shouldBe
@@ -36,14 +32,14 @@ class SocialMemberServiceTest(
 
     describe("소셜 멤버 회원가입 테스트") {
 
-        context("소셜 멤버의 Email이 이미 존재하면") {
-            every { memberRepository.existMemberByEmail(existEmailMember.email) } returns true
-            it("예외가 던져진다.") {
-             shouldThrow<DuplicateEmailException> {
-                 socialMemberService.registerIfAbsent(newAuthInfo)
-             }
-            }
-        }
+//        context("소셜 멤버의 Email이 이미 존재하면") {
+//            every { memberRepository.existMemberByEmail(existEmailMember.email) } returns true
+//            it("예외가 던져진다.") {
+//             shouldThrow<DuplicateEmailException> {
+//                 socialMemberService.registerIfAbsent(newAuthInfo)
+//             }
+//            }
+//        }
 
         context("소셜 멤버의 정보가 서버에 존재하지 않는다면") {
             every { memberRepository.existMemberByEmail(any()) } returns false


### PR DESCRIPTION
- 이메일 중복 처리 코드 삭제

## 연관 이슈
- closes #112

## 해당 작업을 추가/변경한 이유는 무엇인가요?
- 가입한 회원 이메일도 중복처리를 해버림

## 어떤 부분에 리뷰어가 집중하면 좋을까요?
- 더 좋은 의견 있으면 말해주세요

## 리뷰어에게 추가/변경 내용을 상세히 설명해주세요!
- [x] 이메일 중복 처리부분 삭제
