### PR TITLE
✨ Feat: jwt cookie 저장, 헤더에 던지기 기능 추가

### DIFF
--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/auth/OAuth2LoginSuccessHandler.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/auth/OAuth2LoginSuccessHandler.kt
@@ -32,10 +32,11 @@ class OAuth2LoginSuccessHandler(
             val accessToken = jwtPlugin.generateAccessToken(
                 subject = member?.id.toString(),
                 email = userInfo.email,
-                role = MemberRole.MEMBER.name
+                role = MemberRole.MEMBER.name,
+                response = response
             )
+            response.addHeader("Authorization", "Bearer $accessToken")
             response.contentType = MediaType.APPLICATION_JSON_VALUE
-            response.writer.write(accessToken)
         } else {
             response.contentType = MediaType.APPLICATION_JSON_VALUE
             response.writer.write(

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/auth/SocialMemberService.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/auth/SocialMemberService.kt
@@ -8,6 +8,7 @@ import com.challengeteamkotlin.campdaddy.domain.model.member.OAuth2Provider
 import com.challengeteamkotlin.campdaddy.domain.repository.member.MemberRepository
 import com.challengeteamkotlin.campdaddy.infrastructure.jwt.JwtPlugin
 import com.challengeteamkotlin.campdaddy.presentation.auth.dto.request.OAuth2SignupRequest
+import jakarta.servlet.http.HttpServletResponse
 import org.springframework.stereotype.Service
 
 @Service
@@ -16,7 +17,7 @@ class SocialMemberService(
     private val jwtPlugin: JwtPlugin
 ) {
 
-    fun register(signupRequest: OAuth2SignupRequest): String {
+    fun register(signupRequest: OAuth2SignupRequest, response: HttpServletResponse): String {
         val existEmail = memberRepository.existMemberByEmail(signupRequest.email)
         if (existEmail) throw DuplicateEmailException(AuthErrorCode.DUPLICATE_EMAIL)
         return memberRepository.createMember(signupRequest.to())
@@ -24,7 +25,8 @@ class SocialMemberService(
                 jwtPlugin.generateAccessToken(
                     subject = it.id!!.toString(),
                     email = it.email,
-                    role = MemberRole.MEMBER.name
+                    role = MemberRole.MEMBER.name,
+                    response = response
                 )
             }
     }

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/jwt/JwtPlugin.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/jwt/JwtPlugin.kt
@@ -4,6 +4,8 @@ import io.jsonwebtoken.Claims
 import io.jsonwebtoken.Jws
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.security.Keys
+import jakarta.servlet.http.Cookie
+import jakarta.servlet.http.HttpServletResponse
 import org.springframework.stereotype.Component
 import java.nio.charset.StandardCharsets
 import java.time.Duration
@@ -23,8 +25,10 @@ class JwtPlugin(
         }
     }
 
-    fun generateAccessToken(subject: String, email: String, role: String): String {
-        return generateToken(subject, email, role, Duration.ofHours(jwtProperties.accessTokenExpirationHour))
+    fun generateAccessToken(subject: String, email: String, role: String, response: HttpServletResponse): String {
+        val token = generateToken(subject, email, role, Duration.ofHours(jwtProperties.accessTokenExpirationHour))
+        addTokenToCookie(token, response)
+        return token
     }
 
     private fun generateToken(subject: String, email: String, role: String, expirationPeriod: Duration): String {
@@ -43,5 +47,14 @@ class JwtPlugin(
             .claims(claims)
             .signWith(key)
             .compact()
+    }
+
+    private fun addTokenToCookie(token: String, response: HttpServletResponse) {
+        val cookie = Cookie("jwt_token", token)
+        cookie.isHttpOnly = true // JavaScript 에서 쿠키에 접근하지 못하도록 설정
+        cookie.maxAge = (jwtProperties.accessTokenExpirationHour * 60 * 60 * 24 * 7).toInt() // 일주일
+        cookie.path = "/"
+
+        response.addCookie(cookie)
     }
 }

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/auth/dto/OAuth2Controller.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/auth/dto/OAuth2Controller.kt
@@ -2,6 +2,7 @@ package com.challengeteamkotlin.campdaddy.presentation.auth.dto
 
 import com.challengeteamkotlin.campdaddy.application.auth.SocialMemberService
 import com.challengeteamkotlin.campdaddy.presentation.auth.dto.request.OAuth2SignupRequest
+import jakarta.servlet.http.HttpServletResponse
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -16,10 +17,13 @@ class OAuth2Controller(
 
     @PostMapping("/signup")
     fun signup(
-      @Valid @RequestBody signupRequest: OAuth2SignupRequest
+      @Valid @RequestBody signupRequest: OAuth2SignupRequest,
+      response: HttpServletResponse
     ): ResponseEntity<String> {
+        val token = socialMemberService.register(signupRequest, response)
         return ResponseEntity
             .status(HttpStatus.CREATED)
-            .body(socialMemberService.register(signupRequest))
+            .header("Authorization", "Bearer $token")
+            .build()
     }
 }


### PR DESCRIPTION
- cookie 저장
- 헤더에 던지는 로직 추가

## 연관 이슈
- closes #117

## 해당 작업을 추가/변경한 이유는 무엇인가요?
- jwt 토큰을 쿠키에 저장하고 헤더에 던져주기위해

## 어떤 부분에 리뷰어가 집중하면 좋을까요?
- 쿠키 생성 부분, 헤더 로직 부분

## 리뷰어에게 추가/변경 내용을 상세히 설명해주세요!
- [x] jwtplugin 쿠키 저장 로직 추가
- [x] jwt 헤더에 추가 -> body로 나오는부분, 화면에 보이는 부분 없앴음
