### PR TITLE
✨ Feat: Reservation Event 처리 기능 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,6 +103,11 @@ dependencies {
     implementation("org.webjars:sockjs-client:1.1.2")
     implementation("org.webjars:stomp-websocket:2.3.3-1")
 
+    // aws sqs, sns / up to java 11
+    implementation(platform("software.amazon.awssdk:bom:2.20.54"))
+    implementation("software.amazon.awssdk:sns")
+    implementation("software.amazon.awssdk:sqs")
+
 
 }
 

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/CampDaddyApplication.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/CampDaddyApplication.kt
@@ -2,9 +2,7 @@ package com.challengeteamkotlin.campdaddy
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
-import org.springframework.scheduling.annotation.EnableScheduling
 
-@EnableScheduling
 @SpringBootApplication
 class CampDaddyApplication
 

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/CampDaddyApplication.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/CampDaddyApplication.kt
@@ -2,7 +2,9 @@ package com.challengeteamkotlin.campdaddy
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableScheduling
 
+@EnableScheduling
 @SpringBootApplication
 class CampDaddyApplication
 

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/scheduler/SchedulerService.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/scheduler/SchedulerService.kt
@@ -1,0 +1,30 @@
+package com.challengeteamkotlin.campdaddy.application.scheduler
+
+import com.challengeteamkotlin.campdaddy.domain.event.reservation.ReservationEventSubscriber
+import com.challengeteamkotlin.campdaddy.presentation.reservation.dto.event.ReservationEvent
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.treeToValue
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+
+@Service
+class SchedulerService(
+    private val reservationEventSubscriber: ReservationEventSubscriber
+) {
+
+    @Scheduled(fixedRateString = "5000")
+    fun reservationEventListener() {
+        val receiveMessages = reservationEventSubscriber.receiveMessages()
+        receiveMessages.forEach {
+            val reservationEvent = jacksonObjectMapper().readTree(it.body())["Message"]
+                .let { jsonNode -> jacksonObjectMapper().readTree(jsonNode.asText()) }
+                .let { jsonNode -> jacksonObjectMapper().treeToValue<ReservationEvent>(jsonNode) }
+
+            // TODO chatting process
+            println(reservationEvent)
+
+
+            reservationEventSubscriber.deleteMessage(it)
+        }
+    }
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/common/config/SchedulingConfig.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/common/config/SchedulingConfig.kt
@@ -1,0 +1,9 @@
+package com.challengeteamkotlin.campdaddy.common.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableScheduling
+
+
+@Configuration
+@EnableScheduling
+class SchedulingConfig

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/event/reservation/ReservationEventPublisher.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/event/reservation/ReservationEventPublisher.kt
@@ -1,0 +1,7 @@
+package com.challengeteamkotlin.campdaddy.domain.event.reservation
+
+import com.challengeteamkotlin.campdaddy.presentation.reservation.dto.event.ReservationEvent
+
+interface ReservationEventPublisher {
+    fun publish(reservationEvent: ReservationEvent)
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/event/reservation/ReservationEventSubscriber.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/event/reservation/ReservationEventSubscriber.kt
@@ -1,0 +1,11 @@
+package com.challengeteamkotlin.campdaddy.domain.event.reservation
+
+import software.amazon.awssdk.services.sqs.model.Message
+
+
+interface ReservationEventSubscriber {
+
+    fun receiveMessages(): List<Message>
+    fun deleteMessage(message: Message)
+
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/model/reservation/ReservationStatus.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/model/reservation/ReservationStatus.kt
@@ -1,5 +1,9 @@
 package com.challengeteamkotlin.campdaddy.domain.model.reservation
 
-enum class ReservationStatus {
-    REQ, CONFIRM, RENT, END, CANCELED
+enum class ReservationStatus(
+    val value: String
+) {
+    REQ("요청"), CONFIRM("요청 승인"), RENT("대여"), END("대여 종료"), CANCELED("취소")
+
+    ;
 }

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/aws/SnsEventPublisher.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/aws/SnsEventPublisher.kt
@@ -1,0 +1,23 @@
+package com.challengeteamkotlin.campdaddy.infrastructure.aws
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import software.amazon.awssdk.services.sns.SnsClient
+import software.amazon.awssdk.services.sns.model.PublishRequest
+
+class SnsEventPublisher(
+    private val snsClient: SnsClient,
+) {
+
+    fun publishEvent(groupId:String,topicArn: String, anyObject: Any) {
+        return publishEvent(groupId,topicArn, jacksonObjectMapper().writeValueAsString(anyObject))
+    }
+
+    private fun publishEvent(groupId:String,topicArn: String, message: String) {
+        val request = PublishRequest.builder()
+            .topicArn(topicArn)
+            .messageGroupId(groupId)
+            .message(message)
+            .build()
+        snsClient.publish(request)
+    }
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/aws/SqsEventSubscriber.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/aws/SqsEventSubscriber.kt
@@ -1,0 +1,36 @@
+package com.challengeteamkotlin.campdaddy.infrastructure.aws
+
+import software.amazon.awssdk.services.sqs.SqsClient
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest
+import software.amazon.awssdk.services.sqs.model.GetQueueUrlRequest
+import software.amazon.awssdk.services.sqs.model.Message
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
+
+
+class SqsEventSubscriber(
+    private val sqsClient: SqsClient,
+    private val maxNumberOfMessages: Int,
+    private val waitTimeSeconds: Int
+) {
+
+    fun receiveMessages(queueName: String): List<Message> {
+        val queueUrl = sqsClient.getQueueUrl(GetQueueUrlRequest.builder().queueName(queueName).build()).queueUrl()
+
+        val receiveMessageRequest: ReceiveMessageRequest = ReceiveMessageRequest.builder()
+            .queueUrl(queueUrl)
+            .maxNumberOfMessages(maxNumberOfMessages)
+            .waitTimeSeconds(waitTimeSeconds)
+            .build()
+        return sqsClient.receiveMessage(receiveMessageRequest).messages()
+    }
+
+    fun deleteMessage(queueName: String, message: Message) {
+        val queueUrl = sqsClient.getQueueUrl(GetQueueUrlRequest.builder().queueName(queueName).build()).queueUrl()
+
+        val deleteMessageRequest: DeleteMessageRequest = DeleteMessageRequest.builder()
+            .queueUrl(queueUrl)
+            .receiptHandle(message.receiptHandle())
+            .build()
+        sqsClient.deleteMessage(deleteMessageRequest)
+    }
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/aws/config/AwsEventConfig.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/aws/config/AwsEventConfig.kt
@@ -1,0 +1,56 @@
+package com.challengeteamkotlin.campdaddy.infrastructure.aws.config
+
+import com.challengeteamkotlin.campdaddy.infrastructure.aws.SnsEventPublisher
+import com.challengeteamkotlin.campdaddy.infrastructure.aws.SqsEventSubscriber
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.sns.SnsClient
+import software.amazon.awssdk.services.sqs.SqsClient
+
+@Configuration
+class AwsEventConfig(
+    @Value("\${aws.sns-account.access-key}")
+    private var accessKey: String,
+    @Value("\${aws.sns-account.secret-key}")
+    private var secretKey: String,
+    @Value("\${aws.region}")
+    private var region: String,
+) {
+    companion object {
+        const val MAX_NUMBER_OF_MESSAGES = 10
+        const val WAIT_TIME_SECONDS = 5
+    }
+
+    @Bean
+    fun snsClient(): SnsClient {
+        val awsCredentials: AwsBasicCredentials = AwsBasicCredentials.create(accessKey, secretKey)
+        return SnsClient.builder()
+            .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+            .region(Region.of(region))
+            .build()
+    }
+
+    @Bean
+    fun sqsClient(): SqsClient {
+        val awsCredentials: AwsBasicCredentials = AwsBasicCredentials.create(accessKey, secretKey)
+        return SqsClient.builder()
+            .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+            .region(Region.of(region))
+            .build()
+    }
+
+    @Bean
+    fun snsEventPublisher(snsClient: SnsClient): SnsEventPublisher {
+        return SnsEventPublisher(snsClient)
+    }
+
+    @Bean
+    fun sqsEventSubscriber(sqsClient: SqsClient): SqsEventSubscriber {
+        return SqsEventSubscriber(sqsClient, MAX_NUMBER_OF_MESSAGES, WAIT_TIME_SECONDS)
+    }
+
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/event/reservation/ReservationEventPublisherImpl.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/event/reservation/ReservationEventPublisherImpl.kt
@@ -1,0 +1,18 @@
+package com.challengeteamkotlin.campdaddy.infrastructure.event.reservation
+
+import com.challengeteamkotlin.campdaddy.domain.event.reservation.ReservationEventPublisher
+import com.challengeteamkotlin.campdaddy.infrastructure.aws.SnsEventPublisher
+import com.challengeteamkotlin.campdaddy.presentation.reservation.dto.event.ReservationEvent
+import org.springframework.beans.factory.annotation.Value
+
+class ReservationEventPublisherImpl(
+    private val snsEventPublisher: SnsEventPublisher,
+) : ReservationEventPublisher {
+    @Value("\${aws.sns-arn.reservation-change}")
+    lateinit var snsArn: String
+
+    override fun publish(reservationEvent: ReservationEvent) {
+        val groupId = "${reservationEvent.buyerId} ,${reservationEvent.sellerId}"
+        snsEventPublisher.publishEvent(groupId, snsArn, reservationEvent)
+    }
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/event/reservation/ReservationEventSubscriberImpl.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/event/reservation/ReservationEventSubscriberImpl.kt
@@ -1,0 +1,22 @@
+package com.challengeteamkotlin.campdaddy.infrastructure.event.reservation
+
+import com.challengeteamkotlin.campdaddy.domain.event.reservation.ReservationEventSubscriber
+import com.challengeteamkotlin.campdaddy.infrastructure.aws.SqsEventSubscriber
+import org.springframework.beans.factory.annotation.Value
+import software.amazon.awssdk.services.sqs.model.Message
+
+class ReservationEventSubscriberImpl(
+    private val sqsEventSubscriber: SqsEventSubscriber
+) : ReservationEventSubscriber {
+    @Value("\${aws.sqs-name.reservation-change-queue}")
+    lateinit var sqsName: String
+
+
+    override fun receiveMessages(): List<Message> {
+        return sqsEventSubscriber.receiveMessages(sqsName)
+    }
+
+    override fun deleteMessage(message: Message) {
+        return sqsEventSubscriber.deleteMessage(sqsName, message)
+    }
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/reservation/context/event/ReservationEventConfig.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/reservation/context/event/ReservationEventConfig.kt
@@ -1,0 +1,25 @@
+package com.challengeteamkotlin.campdaddy.presentation.reservation.context.event
+
+import com.challengeteamkotlin.campdaddy.domain.event.reservation.ReservationEventPublisher
+import com.challengeteamkotlin.campdaddy.domain.event.reservation.ReservationEventSubscriber
+import com.challengeteamkotlin.campdaddy.infrastructure.aws.SnsEventPublisher
+import com.challengeteamkotlin.campdaddy.infrastructure.aws.SqsEventSubscriber
+import com.challengeteamkotlin.campdaddy.infrastructure.event.reservation.ReservationEventPublisherImpl
+import com.challengeteamkotlin.campdaddy.infrastructure.event.reservation.ReservationEventSubscriberImpl
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class ReservationEventConfig {
+
+    @Bean
+    fun reservationEventPublisher(snsEventPublisher: SnsEventPublisher): ReservationEventPublisher {
+        return ReservationEventPublisherImpl(snsEventPublisher)
+    }
+
+    @Bean
+    fun reservationEventSubscriber(sqsEventSubscriber: SqsEventSubscriber): ReservationEventSubscriber {
+        return ReservationEventSubscriberImpl(sqsEventSubscriber)
+    }
+
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/reservation/context/repository/ReservationRepositoryConfig.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/reservation/context/repository/ReservationRepositoryConfig.kt
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-class ReservationConfig {
+class ReservationRepositoryConfig {
 
     @Bean
     fun reservationRepository(jpaRepository: ReservationJpaRepository): ReservationRepository {

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/reservation/dto/event/ReservationEvent.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/reservation/dto/event/ReservationEvent.kt
@@ -1,0 +1,23 @@
+package com.challengeteamkotlin.campdaddy.presentation.reservation.dto.event
+
+import com.challengeteamkotlin.campdaddy.domain.model.reservation.ReservationEntity
+
+
+data class ReservationEvent(
+    val productId: Long,
+    val buyerId: Long,
+    val sellerId: Long,
+    val changeStatus: String
+) {
+
+    companion object {
+        fun of(reservationEntity: ReservationEntity): ReservationEvent {
+            return ReservationEvent(
+                productId = reservationEntity.product.id!!,
+                buyerId = reservationEntity.member.id!!,
+                sellerId = reservationEntity.product.member.id!!,
+                changeStatus = reservationEntity.reservationStatus.value
+            )
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -77,3 +77,13 @@ auth:
     accessTokenExpirationHour: ${JWT_ACCESS_EXPIRATION_HOUR}
 
 
+aws:
+  region: ap-northeast-2
+  sns-account:
+    access-key: ${SNS_ACCESS_KEY}
+    secret-key: ${SNS_SECRET_KEY}
+  sns-arn:
+    reservation-change: ${SNS_RESERVATION_ARN}
+  sqs-name:
+    reservation-change-queue: ${SQS_RESERVATION_NAME}
+

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -69,3 +69,12 @@ auth:
     accessTokenExpirationHour: ${JWT_ACCESS_EXPIRATION_HOUR}
 
 
+aws:
+  region: ap-northeast-2
+  sns-account:
+    access-key: ${SNS_ACCESS_KEY}
+    secret-key: ${SNS_SECRET_KEY}
+  sns-arn:
+    reservation-change: ${SNS_RESERVATION_ARN}
+  sqs-name:
+    reservation-change-queue: ${SQS_RESERVATION_NAME}


### PR DESCRIPTION
## 연관 이슈
- closes #119 

## 해당 작업을 추가/변경한 이유는 무엇인가요?
- Reservation Event 처리 기능 추가

## 어떤 부분에 리뷰어가 집중하면 좋을까요?
- 외부 의존성에 대한 역전을 위해 interface를 이용하여 dip를 적용하였습니다.
- dip 적용 중 이상하거나 더 나은 방법이 있는지 봐주세요.
- 코드 중 리팩토링이 필요한 부분이 있는지 봐주세요.

## 리뷰어에게 추가/변경 내용을 상세히 설명해주세요!
- [x] aws 관련 설정 application.yml 추가
- [x] aws sns, sqs 활용 publish, listening 기능 추가
- [x] aws sns,sqs 를 활용한 ReservationEventPublisherImpl, ReservationEventSubscriberImpl 구현
- [x] 각 의존성 관리를 위한 config 설정
- [x] Reservation의 생성, 상태 수정 시 event 발행 코드 추가
- [x] event에 값을 담기 위해 ReservationStatus Enum에 value 추가
- [x] SchedulerService에서 스케쥴링을 통해 reservationEventListener 추가
