### PR TITLE
♻️ Refactor: 채팅 조회기능 리팩토링 적용

### DIFF
--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/chat/ChatRoomService.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/chat/ChatRoomService.kt
@@ -12,8 +12,7 @@ import com.challengeteamkotlin.campdaddy.domain.repository.product.ProductReposi
 import com.challengeteamkotlin.campdaddy.presentation.chat.dto.request.CreateChatRoomRequest
 import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.ChatRoomDetailResponse
 import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.ChatRoomResponse
-import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.MessageResponse
-import org.springframework.data.repository.findByIdOrNull
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -51,11 +50,9 @@ class ChatRoomService(
     }
 
     @Transactional(readOnly = true)
-    fun getChatDetail(roomId: Long): ChatRoomDetailResponse {
+    fun getChatDetail(roomId: Long, page: Pageable): ChatRoomDetailResponse {
         val chatRoom = getChatRoom(roomId)
-        val chatMessages = chatMessageRepository.getChatMessageByChatRoomId(chatRoom.id!!)?.map {
-            MessageResponse.from(it)
-        } ?: emptyList()
+        val chatMessages = chatMessageRepository.getChatMessageByChatRoomId(chatRoom.id!!, page)
 
         return ChatRoomDetailResponse.of(chatRoom, chatMessages)
     }

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/repository/chat/ChatMessageRepository.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/repository/chat/ChatMessageRepository.kt
@@ -1,9 +1,12 @@
 package com.challengeteamkotlin.campdaddy.domain.repository.chat
 
 import com.challengeteamkotlin.campdaddy.domain.model.chat.ChatMessageEntity
+import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.MessageResponse
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 
 interface ChatMessageRepository {
     fun createChatMessage(chatMessageEntity: ChatMessageEntity): ChatMessageEntity
     fun getLatestChatMessage(chatRoomId: Long): ChatMessageEntity
-    fun getChatMessageByChatRoomId(chatRoomId: Long): List<ChatMessageEntity>?
+    fun getChatMessageByChatRoomId(chatRoomId: Long, page: Pageable): Slice<MessageResponse>
 }

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/repository/chat/ChatMessageRepositoryImpl.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/repository/chat/ChatMessageRepositoryImpl.kt
@@ -2,9 +2,14 @@ package com.challengeteamkotlin.campdaddy.domain.repository.chat
 
 import com.challengeteamkotlin.campdaddy.domain.model.chat.ChatMessageEntity
 import com.challengeteamkotlin.campdaddy.infrastructure.hibernate.chat.ChatMessageJpaRepository
+import com.challengeteamkotlin.campdaddy.infrastructure.hibernate.chat.ChatMessageQueryDslRepository
+import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.MessageResponse
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 
 class ChatMessageRepositoryImpl(
     private val chatMessageJpaRepository: ChatMessageJpaRepository,
+    private val chatMessageQueryDslRepository: ChatMessageQueryDslRepository,
 ) : ChatMessageRepository {
 
     override fun createChatMessage(chatMessageEntity: ChatMessageEntity): ChatMessageEntity {
@@ -15,7 +20,7 @@ class ChatMessageRepositoryImpl(
         return chatMessageJpaRepository.findFirstByChatRoomIdOrderByCreatedAt(chatRoomId)
     }
 
-    override fun getChatMessageByChatRoomId(chatRoomId: Long): List<ChatMessageEntity>? {
-        return chatMessageJpaRepository.findByChatRoomId(chatRoomId)
+    override fun getChatMessageByChatRoomId(chatRoomId: Long, page: Pageable): Slice<MessageResponse> {
+        return chatMessageQueryDslRepository.getChatMessageByChatRoomId(chatRoomId, page)
     }
 }

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/hibernate/chat/ChatMessageJpaRepository.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/hibernate/chat/ChatMessageJpaRepository.kt
@@ -4,6 +4,5 @@ import com.challengeteamkotlin.campdaddy.domain.model.chat.ChatMessageEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface ChatMessageJpaRepository : JpaRepository<ChatMessageEntity, Long> {
-    fun findByChatRoomId(roomId: Long): List<ChatMessageEntity>?
     fun findFirstByChatRoomIdOrderByCreatedAt(roomId: Long): ChatMessageEntity
 }

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/hibernate/chat/ChatMessageQueryDslRepository.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/hibernate/chat/ChatMessageQueryDslRepository.kt
@@ -1,0 +1,12 @@
+package com.challengeteamkotlin.campdaddy.infrastructure.hibernate.chat
+
+import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.MessageResponse
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import org.springframework.stereotype.Repository
+
+@Repository
+interface ChatMessageQueryDslRepository {
+
+    fun getChatMessageByChatRoomId(roomId: Long, page: Pageable): Slice<MessageResponse>
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/hibernate/chat/ChatMessageQueryDslRepositoryImpl.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/hibernate/chat/ChatMessageQueryDslRepositoryImpl.kt
@@ -1,0 +1,46 @@
+package com.challengeteamkotlin.campdaddy.infrastructure.hibernate.chat
+
+import com.challengeteamkotlin.campdaddy.domain.model.chat.QChatMessageEntity
+import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.MessageResponse
+import com.querydsl.core.types.Projections
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import org.springframework.data.domain.SliceImpl
+
+class ChatMessageQueryDslRepositoryImpl(
+    private val queryFactory: JPAQueryFactory,
+) : ChatMessageQueryDslRepository {
+
+    private val chatMessage = QChatMessageEntity.chatMessageEntity
+
+    override fun getChatMessageByChatRoomId(roomId: Long, page: Pageable): Slice<MessageResponse> {
+        val response = queryFactory.select(
+            Projections.constructor(
+                MessageResponse::class.java,
+                chatMessage.member.nickname,
+                chatMessage.message,
+                chatMessage.createdAt
+            )
+        ).from(chatMessage)
+            .where(chatMessage.id.lt(roomId))
+            .orderBy(chatMessage.createdAt.desc())
+            .limit(page.pageSize.toLong() + 1)
+            .fetch()
+
+        return checkLastPage(response, page)
+    }
+
+    // 마지막 페이지 확인
+    private fun checkLastPage(response: MutableList<MessageResponse>, page: Pageable): Slice<MessageResponse> {
+
+        var hasNext = false
+
+        if (response.size > page.pageSize) {
+            response.removeAt(response.size - 1)
+            hasNext = true
+        }
+
+        return SliceImpl(response, page, hasNext)
+    }
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/hibernate/querydsl/QueryDslSupport.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/hibernate/querydsl/QueryDslSupport.kt
@@ -1,0 +1,16 @@
+package com.challengeteamkotlin.campdaddy.infrastructure.hibernate.querydsl
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class QueryDslSupport(
+    @PersistenceContext
+    private var entityManager: EntityManager
+) {
+    @Bean
+    fun queryFactory() = JPAQueryFactory(entityManager)
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/ChatRoomController.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/ChatRoomController.kt
@@ -4,6 +4,7 @@ import com.challengeteamkotlin.campdaddy.application.chat.ChatRoomService
 import com.challengeteamkotlin.campdaddy.presentation.chat.dto.request.CreateChatRoomRequest
 import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.ChatRoomDetailResponse
 import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.ChatRoomResponse
+import org.springframework.data.domain.PageRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import java.net.URI
@@ -11,7 +12,7 @@ import java.net.URI
 @RestController
 @RequestMapping("/chatroom")
 class ChatRoomController(
-    private val chatRoomService: ChatRoomService
+    private val chatRoomService: ChatRoomService,
 ) {
     @PostMapping
     fun createChat(@RequestBody request: CreateChatRoomRequest): ResponseEntity<Unit> {
@@ -29,7 +30,7 @@ class ChatRoomController(
 
     @GetMapping("/{roomId}")
     fun getChat(@PathVariable roomId: Long): ResponseEntity<ChatRoomDetailResponse> {
-        val chatList = chatRoomService.getChatDetail(roomId)
+        val chatList = chatRoomService.getChatDetail(roomId, PageRequest.of(0, 20))
 
         return ResponseEntity.ok().body(chatList)
     }

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/context/repository/ChatConfig.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/context/repository/ChatConfig.kt
@@ -5,6 +5,7 @@ import com.challengeteamkotlin.campdaddy.domain.repository.chat.ChatMessageRepos
 import com.challengeteamkotlin.campdaddy.domain.repository.chat.ChatRoomRepository
 import com.challengeteamkotlin.campdaddy.domain.repository.chat.ChatRoomRepositoryImpl
 import com.challengeteamkotlin.campdaddy.infrastructure.hibernate.chat.ChatMessageJpaRepository
+import com.challengeteamkotlin.campdaddy.infrastructure.hibernate.chat.ChatMessageQueryDslRepository
 import com.challengeteamkotlin.campdaddy.infrastructure.hibernate.chat.ChatRoomJpaRepository
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -13,8 +14,11 @@ import org.springframework.context.annotation.Configuration
 class ChatConfig {
 
     @Bean
-    fun chatMessageRepository(jpaRepository: ChatMessageJpaRepository): ChatMessageRepository {
-        return ChatMessageRepositoryImpl(jpaRepository)
+    fun chatMessageRepository(
+        jpaRepository: ChatMessageJpaRepository,
+        queryDslRepository: ChatMessageQueryDslRepository,
+    ): ChatMessageRepository {
+        return ChatMessageRepositoryImpl(jpaRepository, queryDslRepository)
     }
 
     @Bean

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/dto/response/ChatRoomDetailResponse.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/dto/response/ChatRoomDetailResponse.kt
@@ -2,15 +2,18 @@ package com.challengeteamkotlin.campdaddy.presentation.chat.dto.response
 
 import com.challengeteamkotlin.campdaddy.domain.model.chat.ChatRoomEntity
 import com.challengeteamkotlin.campdaddy.presentation.product.dto.response.ProductDetailResponse
+import org.springframework.data.domain.Slice
 
 data class ChatRoomDetailResponse(
     val productDetail: ProductDetailResponse,
     val chatHistory: List<MessageResponse>,
+    val hasNext: Boolean
 ) {
     companion object {
-        fun of(chatRoom: ChatRoomEntity, chatHistory: List<MessageResponse>) = ChatRoomDetailResponse(
+        fun of(chatRoom: ChatRoomEntity, chatMessagePage: Slice<MessageResponse>) = ChatRoomDetailResponse(
             productDetail = ProductDetailResponse.from(chatRoom.product),
-            chatHistory = chatHistory
+            chatHistory = chatMessagePage.content,
+            hasNext = chatMessagePage.hasNext()
         )
     }
 }

--- a/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/chat/ChatMessageFixture.kt
+++ b/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/chat/ChatMessageFixture.kt
@@ -3,12 +3,14 @@ package com.challengeteamkotlin.campdaddy.fixture.chat
 import com.challengeteamkotlin.campdaddy.domain.model.chat.MessageStatus
 import com.challengeteamkotlin.campdaddy.presentation.chat.dto.request.MessageRequest
 import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.MessageResponse
+import org.springframework.data.domain.PageRequest
 import java.time.LocalDateTime
 
 object ChatMessageFixture {
     // Request
     val messageRequest = MessageRequest(200, "안녕하세요", MessageStatus.MESSAGE)
 
+    val chatPageRequest = PageRequest.of(0, 20)
     // Response
     val messageResponseFirst = MessageResponse("unknown", "빌리고 싶습니다", LocalDateTime.now())
     val messageResponseSecond = MessageResponse("unknown", "빌리고 싶습니다", LocalDateTime.now())

--- a/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/chat/ChatRoomFixture.kt
+++ b/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/chat/ChatRoomFixture.kt
@@ -38,7 +38,8 @@ object ChatRoomFixture {
 
     val chatRoomResponse = ChatRoomDetailResponse(
         productDetail = productDetail,
-        chatHistory = chatMessageResponse
+        chatHistory = chatMessageResponse,
+        hasNext = true
     )
 
     // Entity


### PR DESCRIPTION
## 연관 이슈
- closes #121 

## 해당 작업을 추가/변경한 이유는 무엇인가요?
- 채팅 메세지 조회시 페이지네이션을 적용하여 조회 성능을 개선합니다.

## 어떤 부분에 리뷰어가 집중하면 좋을까요?
- 저희 도메인 특성상 한 채팅방( `1:1` )에서 많아도 1,000건 이상의 대화를 나눌거 같진 않은데 꼭 페이지네이션 적용이 필요한지가 개발해보니까 의문이 드네요 리뷰어 분들도 필요없다고 동의하신다면 이 PR은 삭제해도 무관할 것 같아요

## 리뷰어에게 추가/변경 내용을 상세히 설명해주세요!
- [x] QueryDsl 사용을 위한 Support 클래스 추가
- [x] ChatMessageQueryDslRepository 추가
- [x] 채팅방 디테일 Response DTO 프로퍼티 추가
- [x] 채팅 메세지 조회 Controller / Service 변경 적용
- [x] Fixture 수정
- [x] ChatMessage 관련 테스트 코드 수정
