### PR TITLE
✨ Feat: Reservation Event 처리 채팅 연동 기능 추가

### DIFF
--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/chat/ChatMessageSendManager.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/chat/ChatMessageSendManager.kt
@@ -19,7 +19,7 @@ class ChatMessageSendManager(
             is ReservationEvent -> {
                 val messageRequest = MessageRequest(
                     userId = ADMIN_ID,
-                    message = "예약 상태가 $request.changeStatus(으)로 변경되었습니다.",
+                    message = "예약 상태가 ${request.changeStatus.value}(으)로 변경되었습니다.",
                     status = MessageStatus.NOTICE
                 )
 

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/chat/ChatMessageSendManager.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/chat/ChatMessageSendManager.kt
@@ -1,0 +1,36 @@
+package com.challengeteamkotlin.campdaddy.application.chat
+
+import com.challengeteamkotlin.campdaddy.domain.model.chat.MessageStatus
+import com.challengeteamkotlin.campdaddy.presentation.chat.dto.request.MessageRequest
+import com.challengeteamkotlin.campdaddy.presentation.reservation.dto.event.ReservationEvent
+import org.springframework.messaging.simp.SimpMessageSendingOperations
+import org.springframework.stereotype.Component
+
+@Component
+class ChatMessageSendManager(
+    private val simpMessageTemplate: SimpMessageSendingOperations,
+) {
+
+    private final val ADMIN_ID = 9999L
+    private final val SUBSCRIBE_DESTINATION = "/sub/chat"
+
+    fun sendToChatRoom(roomId: Long, request: Any) {
+        when (request) {
+            is ReservationEvent -> {
+                val messageRequest = MessageRequest(
+                    userId = ADMIN_ID,
+                    message = "예약 상태가 $request.changeStatus(으)로 변경되었습니다.",
+                    status = MessageStatus.NOTICE
+                )
+
+                simpMessageTemplate.convertAndSend("$SUBSCRIBE_DESTINATION/$roomId", messageRequest)
+            }
+
+            is MessageRequest -> {
+                simpMessageTemplate.convertAndSend("$SUBSCRIBE_DESTINATION/$roomId", request)
+            }
+
+        }
+    }
+
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/chat/ChatRoomService.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/chat/ChatRoomService.kt
@@ -13,7 +13,6 @@ import com.challengeteamkotlin.campdaddy.presentation.chat.dto.request.CreateCha
 import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.ChatRoomDetailResponse
 import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.ChatRoomResponse
 import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.MessageResponse
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/scheduler/SchedulerService.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/scheduler/SchedulerService.kt
@@ -2,9 +2,15 @@ package com.challengeteamkotlin.campdaddy.application.scheduler
 
 import com.challengeteamkotlin.campdaddy.application.chat.ChatMessageSendManager
 import com.challengeteamkotlin.campdaddy.application.chat.exception.ChatErrorCode
+import com.challengeteamkotlin.campdaddy.application.member.exception.MemberErrorCode
+import com.challengeteamkotlin.campdaddy.application.product.exception.ProductErrorCode
 import com.challengeteamkotlin.campdaddy.common.exception.EntityNotFoundException
 import com.challengeteamkotlin.campdaddy.domain.event.reservation.ReservationEventSubscriber
+import com.challengeteamkotlin.campdaddy.domain.model.reservation.ReservationStatus
 import com.challengeteamkotlin.campdaddy.domain.repository.chat.ChatRoomRepository
+import com.challengeteamkotlin.campdaddy.domain.repository.member.MemberRepository
+import com.challengeteamkotlin.campdaddy.domain.repository.product.ProductRepository
+import com.challengeteamkotlin.campdaddy.presentation.chat.dto.request.CreateChatRoomRequest
 import com.challengeteamkotlin.campdaddy.presentation.reservation.dto.event.ReservationEvent
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.treeToValue
@@ -15,6 +21,8 @@ import org.springframework.stereotype.Service
 class SchedulerService(
     private val reservationEventSubscriber: ReservationEventSubscriber,
     private val chatRoomRepository: ChatRoomRepository,
+    private val productRepository: ProductRepository,
+    private val memberRepository: MemberRepository,
     private val chatMessageSendManager: ChatMessageSendManager,
 ) {
 
@@ -26,8 +34,21 @@ class SchedulerService(
                 .let { jsonNode -> jacksonObjectMapper().readTree(jsonNode.asText()) }
                 .let { jsonNode -> jacksonObjectMapper().treeToValue<ReservationEvent>(jsonNode) }
                 .run {
-                    val chatRoom = chatRoomRepository.getChatRoomByBuyerIdAndProductId(this.buyerId, this.productId)
-                        ?: throw EntityNotFoundException(ChatErrorCode.CHAT_NOT_FOUND)
+                    val chatRoom =
+                        when (this.changeStatus) {
+                        ReservationStatus.REQ -> chatRoomRepository.getChatRoomByBuyerIdAndProductId(this.buyerId, this.productId) ?: throw EntityNotFoundException(ChatErrorCode.CHAT_NOT_FOUND)
+
+                        else -> {
+                            val createChatRoomRequest = CreateChatRoomRequest(this.buyerId, this.productId)
+
+                            val buyer = memberRepository.getMemberByIdOrNull(this.buyerId) ?: throw EntityNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND)
+                            val seller = memberRepository.getMemberByIdOrNull(this.sellerId) ?: throw EntityNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND)
+                            val product = productRepository.getProductById(this.productId) ?: throw EntityNotFoundException(ProductErrorCode.PRODUCT_NOT_FOUND_EXCEPTION)
+
+                            chatRoomRepository.getChatRoomByBuyerIdAndProductId(this.buyerId, this.productId) ?: chatRoomRepository.createChat(createChatRoomRequest.of(buyer, seller, product))
+                        }
+                    }
+
                     chatMessageSendManager.sendToChatRoom(chatRoom.id!!, it)
                 }
 

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/scheduler/SchedulerService.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/scheduler/SchedulerService.kt
@@ -1,6 +1,10 @@
 package com.challengeteamkotlin.campdaddy.application.scheduler
 
+import com.challengeteamkotlin.campdaddy.application.chat.ChatMessageSendManager
+import com.challengeteamkotlin.campdaddy.application.chat.exception.ChatErrorCode
+import com.challengeteamkotlin.campdaddy.common.exception.EntityNotFoundException
 import com.challengeteamkotlin.campdaddy.domain.event.reservation.ReservationEventSubscriber
+import com.challengeteamkotlin.campdaddy.domain.repository.chat.ChatRoomRepository
 import com.challengeteamkotlin.campdaddy.presentation.reservation.dto.event.ReservationEvent
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.treeToValue
@@ -9,20 +13,23 @@ import org.springframework.stereotype.Service
 
 @Service
 class SchedulerService(
-    private val reservationEventSubscriber: ReservationEventSubscriber
+    private val reservationEventSubscriber: ReservationEventSubscriber,
+    private val chatRoomRepository: ChatRoomRepository,
+    private val chatMessageSendManager: ChatMessageSendManager,
 ) {
 
     @Scheduled(fixedRateString = "5000")
     fun reservationEventListener() {
         val receiveMessages = reservationEventSubscriber.receiveMessages()
         receiveMessages.forEach {
-            val reservationEvent = jacksonObjectMapper().readTree(it.body())["Message"]
+            jacksonObjectMapper().readTree(it.body())["Message"]
                 .let { jsonNode -> jacksonObjectMapper().readTree(jsonNode.asText()) }
                 .let { jsonNode -> jacksonObjectMapper().treeToValue<ReservationEvent>(jsonNode) }
-
-            // TODO chatting process
-            println(reservationEvent)
-
+                .run {
+                    val chatRoom = chatRoomRepository.getChatRoomByBuyerIdAndProductId(this.buyerId, this.productId)
+                        ?: throw EntityNotFoundException(ChatErrorCode.CHAT_NOT_FOUND)
+                    chatMessageSendManager.sendToChatRoom(chatRoom.id!!, it)
+                }
 
             reservationEventSubscriber.deleteMessage(it)
         }

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/MessageStatus.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/model/chat/MessageStatus.kt
@@ -1,5 +1,5 @@
 package com.challengeteamkotlin.campdaddy.domain.model.chat
 
 enum class MessageStatus {
-    MESSAGE, IMAGE
+    MESSAGE, IMAGE, NOTICE
 }

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/ChatMessageController.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/ChatMessageController.kt
@@ -1,27 +1,26 @@
 package com.challengeteamkotlin.campdaddy.presentation.chat
 
+import com.challengeteamkotlin.campdaddy.application.chat.ChatMessageSendManager
 import com.challengeteamkotlin.campdaddy.application.chat.ChatMessageService
 import com.challengeteamkotlin.campdaddy.presentation.chat.dto.request.MessageRequest
 import jakarta.validation.Valid
 import org.springframework.messaging.handler.annotation.DestinationVariable
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.messaging.handler.annotation.Payload
-import org.springframework.messaging.simp.SimpMessageSendingOperations
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class ChatMessageController(
     private val chatMessageService: ChatMessageService,
-    private val simpMessageTemplate: SimpMessageSendingOperations,
+    private val chatMessageSendManager: ChatMessageSendManager
 ) {
-    private final val SUBSCRIBE_DESTINATION = "/sub/chat/"
 
     @MessageMapping("/chat/{roomId}")
     fun chat(
         @DestinationVariable roomId: Long,
-        @Payload @Valid request: MessageRequest
+        @Payload @Valid request: MessageRequest,
     ) {
-        simpMessageTemplate.convertAndSend("$SUBSCRIBE_DESTINATION$roomId", request)
+        chatMessageSendManager.sendToChatRoom(roomId, request)
         chatMessageService.save(roomId, request)
     }
 

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/reservation/dto/event/ReservationEvent.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/reservation/dto/event/ReservationEvent.kt
@@ -1,13 +1,14 @@
 package com.challengeteamkotlin.campdaddy.presentation.reservation.dto.event
 
 import com.challengeteamkotlin.campdaddy.domain.model.reservation.ReservationEntity
+import com.challengeteamkotlin.campdaddy.domain.model.reservation.ReservationStatus
 
 
 data class ReservationEvent(
     val productId: Long,
     val buyerId: Long,
     val sellerId: Long,
-    val changeStatus: String
+    val changeStatus: ReservationStatus
 ) {
 
     companion object {
@@ -16,7 +17,7 @@ data class ReservationEvent(
                 productId = reservationEntity.product.id!!,
                 buyerId = reservationEntity.member.id!!,
                 sellerId = reservationEntity.product.member.id!!,
-                changeStatus = reservationEntity.reservationStatus.value
+                changeStatus = reservationEntity.reservationStatus
             )
         }
     }


### PR DESCRIPTION
## 연관 이슈
- closes #122 

## 해당 작업을 추가/변경한 이유는 무엇인가요?
- WebSocket인 STOMP 프로토콜을 사용하여 예약 변경에 대한 내용을 전송하기 위함입니다.
- 이에 따라 메세지 전송을 위한 Manager가 따로 존재하는게 좋겠다고 생각하여 ChatMessageSendManager를 만들었습니다.

## 어떤 부분에 리뷰어가 집중하면 좋을까요?
- ADMIN 멤버에 대한 ID를 그대로 노출시키는게 맞나 싶습니다. 

## 리뷰어에게 추가/변경 내용을 상세히 설명해주세요!
- [x] MessageStatus 상태값 추가(NOTICE)
- [x] SchedulerService 채팅 전송 기능 추가
- [x] SimpMessageSendingOperations 통합(ChatMessageSendManager.kt)
