### PR TITLE
✨ Feat: 예약 event groupId, 중복제거 Id 기능 추가

### DIFF
--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/aws/SnsEventPublisher.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/aws/SnsEventPublisher.kt
@@ -3,6 +3,7 @@ package com.challengeteamkotlin.campdaddy.infrastructure.aws
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import software.amazon.awssdk.services.sns.SnsClient
 import software.amazon.awssdk.services.sns.model.PublishRequest
+import java.util.*
 
 class SnsEventPublisher(
     private val snsClient: SnsClient,
@@ -17,6 +18,7 @@ class SnsEventPublisher(
             .topicArn(topicArn)
             .messageGroupId(groupId)
             .message(message)
+            .messageDeduplicationId(UUID.randomUUID().toString())
             .build()
         snsClient.publish(request)
     }

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/event/reservation/ReservationEventPublisherImpl.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/event/reservation/ReservationEventPublisherImpl.kt
@@ -12,7 +12,7 @@ class ReservationEventPublisherImpl(
     lateinit var snsArn: String
 
     override fun publish(reservationEvent: ReservationEvent) {
-        val groupId = "${reservationEvent.buyerId} ,${reservationEvent.sellerId}"
+        val groupId = "${reservationEvent.buyerId},${reservationEvent.sellerId},${reservationEvent.productId}"
         snsEventPublisher.publishEvent(groupId, snsArn, reservationEvent)
     }
 }


### PR DESCRIPTION
## 연관 이슈
- closes #126 

## 해당 작업을 추가/변경한 이유는 무엇인가요?
- 기존 컨텐츠 기반 중복제거 시 테스트가 어려운 문제를 해결.
- 순서보장 해주는 단위인 groupId에 productId가 추가 되어야 함.

## 리뷰어에게 추가/변경 내용을 상세히 설명해주세요!
- [x] publishEvent에 messageDeduplicationId 추가
- [x] groupId에 productId추가
