### PR TITLE
♻️ Refactor: 채팅 도메인 인증 / 개인 채팅 조회 기능 리팩토링 적용

### DIFF
--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/chat/ChatRoomService.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/application/chat/ChatRoomService.kt
@@ -3,7 +3,9 @@ package com.challengeteamkotlin.campdaddy.application.chat
 import com.challengeteamkotlin.campdaddy.application.chat.exception.ChatErrorCode
 import com.challengeteamkotlin.campdaddy.application.member.exception.MemberErrorCode
 import com.challengeteamkotlin.campdaddy.application.product.exception.ProductErrorCode
+import com.challengeteamkotlin.campdaddy.common.auth.isAuthorized
 import com.challengeteamkotlin.campdaddy.common.exception.EntityNotFoundException
+import com.challengeteamkotlin.campdaddy.common.security.UserPrincipal
 import com.challengeteamkotlin.campdaddy.domain.model.chat.ChatRoomEntity
 import com.challengeteamkotlin.campdaddy.domain.repository.chat.ChatMessageRepository
 import com.challengeteamkotlin.campdaddy.domain.repository.chat.ChatRoomRepository
@@ -26,8 +28,12 @@ class ChatRoomService(
 
     @Transactional
     fun createChat(request: CreateChatRoomRequest): Long {
-        val buyer = memberRepository.getMemberByIdOrNull(request.buyerId) ?: throw EntityNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND)
-        val product = productRepository.getProductById(request.productId) ?: throw EntityNotFoundException(ProductErrorCode.PRODUCT_NOT_FOUND_EXCEPTION)
+        val buyer = memberRepository.getMemberByIdOrNull(request.buyerId) ?: throw EntityNotFoundException(
+            MemberErrorCode.MEMBER_NOT_FOUND
+        )
+        val product = productRepository.getProductById(request.productId) ?: throw EntityNotFoundException(
+            ProductErrorCode.PRODUCT_NOT_FOUND_EXCEPTION
+        )
 
         return when (val chatRoom = chatRoomRepository.getChatRoomByBuyerIdAndProductId(request.buyerId, request.productId)) {
             null -> chatRoomRepository.createChat(request.of(buyer, product.member, product)).id!!
@@ -36,34 +42,32 @@ class ChatRoomService(
     }
 
     @Transactional(readOnly = true)
-    fun getPersonalChatList(memberId: Long): List<ChatRoomResponse>? {
-        val member = memberRepository.getMemberByIdOrNull(memberId) ?: throw EntityNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND)
-
-        return chatRoomRepository.getChatRoomByBuyerIdOrSellerId(member.id!!, member.id!!)?.map {
-            val latestChat = chatMessageRepository.getLatestChatMessage(it.id!!)
-
-            when (it.buyer) {
-                member -> ChatRoomResponse.of(it.seller, it.product, latestChat)
-                else -> ChatRoomResponse.of(it.buyer, it.product, latestChat)
-            }
-        } ?: emptyList()
+    fun getPersonalChatList(memberId: Long, userPrincipal: UserPrincipal): List<ChatRoomResponse>? {
+        return isAuthorized(memberId, userPrincipal) {
+            chatRoomRepository.getPersonalChatList(memberId)
+        }
     }
 
     @Transactional(readOnly = true)
-    fun getChatDetail(roomId: Long): ChatRoomDetailResponse {
+    fun getChatDetail(roomId: Long, userPrincipal: UserPrincipal): ChatRoomDetailResponse {
         val chatRoom = getChatRoom(roomId)
-        val chatMessages = chatMessageRepository.getChatMessageByChatRoomId(chatRoom.id!!)?.map {
-            MessageResponse.from(it)
-        } ?: emptyList()
 
-        return ChatRoomDetailResponse.of(chatRoom, chatMessages)
+        return isAuthorized(userPrincipal.id, chatRoom.seller.id!!, chatRoom.buyer.id!!) {
+            val chatMessages = chatMessageRepository.getChatMessageByChatRoomId(chatRoom.id!!)?.map {
+                MessageResponse.from(it)
+            } ?: emptyList()
+
+            ChatRoomDetailResponse.of(chatRoom, chatMessages)
+        }
     }
 
     @Transactional
-    fun removeChat(roomId: Long) {
+    fun removeChat(roomId: Long, userPrincipal: UserPrincipal) {
         val chatRoom = getChatRoom(roomId)
 
-        chatRoomRepository.removeChat(chatRoom)
+        return isAuthorized(userPrincipal.id, chatRoom.seller.id!!, chatRoom.buyer.id!!) {
+            chatRoomRepository.removeChat(chatRoom)
+        }
     }
 
     private fun getChatRoom(roomId: Long): ChatRoomEntity {

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/common/auth/UserAuthorization.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/common/auth/UserAuthorization.kt
@@ -5,11 +5,24 @@ import com.challengeteamkotlin.campdaddy.common.exception.UnAuthorizationExcepti
 import com.challengeteamkotlin.campdaddy.common.security.UserPrincipal
 
 fun <T> isAuthorized(
-    id: Long,
+    targetId: Long,
     userPrincipal: UserPrincipal,
     func: () -> T
 ): T {
-    if (id == userPrincipal.id) {
+    if (targetId == userPrincipal.id) {
+        return func.invoke()
+    } else {
+        throw UnAuthorizationException(AuthErrorCode.ACCESS_DENIED)
+    }
+}
+
+fun <T> isAuthorized(
+    id: Long,
+    sellerId: Long,
+    buyerId: Long,
+    func: () -> T
+): T {
+    if (id == sellerId || id == buyerId) {
         return func.invoke()
     } else {
         throw UnAuthorizationException(AuthErrorCode.ACCESS_DENIED)

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/repository/chat/ChatRoomRepository.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/repository/chat/ChatRoomRepository.kt
@@ -1,11 +1,12 @@
 package com.challengeteamkotlin.campdaddy.domain.repository.chat
 
 import com.challengeteamkotlin.campdaddy.domain.model.chat.ChatRoomEntity
+import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.ChatRoomResponse
 
 interface ChatRoomRepository {
     fun createChat(chatRoom: ChatRoomEntity): ChatRoomEntity
     fun getChatRoomById(roomId: Long): ChatRoomEntity?
     fun getChatRoomByBuyerIdAndProductId(buyerId: Long, productId: Long): ChatRoomEntity?
-    fun getChatRoomByBuyerIdOrSellerId(buyerId: Long, sellerId: Long): List<ChatRoomEntity>?
+    fun getPersonalChatList(memberId: Long): List<ChatRoomResponse>
     fun removeChat(chatRoom: ChatRoomEntity)
 }

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/repository/chat/ChatRoomRepositoryImpl.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/domain/repository/chat/ChatRoomRepositoryImpl.kt
@@ -2,10 +2,13 @@ package com.challengeteamkotlin.campdaddy.domain.repository.chat
 
 import com.challengeteamkotlin.campdaddy.domain.model.chat.ChatRoomEntity
 import com.challengeteamkotlin.campdaddy.infrastructure.hibernate.chat.ChatRoomJpaRepository
+import com.challengeteamkotlin.campdaddy.infrastructure.hibernate.chat.ChatRoomQueryDslRepository
+import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.ChatRoomResponse
 import org.springframework.data.repository.findByIdOrNull
 
 class ChatRoomRepositoryImpl(
-    private val chatRoomJpaRepository: ChatRoomJpaRepository
+    private val chatRoomJpaRepository: ChatRoomJpaRepository,
+    private val chatRoomQueryDslRepository: ChatRoomQueryDslRepository
 ) : ChatRoomRepository {
 
     override fun createChat(chatRoom: ChatRoomEntity): ChatRoomEntity {
@@ -20,8 +23,8 @@ class ChatRoomRepositoryImpl(
         return chatRoomJpaRepository.findByBuyerIdAndProductId(buyerId, productId)
     }
 
-    override fun getChatRoomByBuyerIdOrSellerId(buyerId: Long, sellerId: Long): List<ChatRoomEntity>? {
-        return chatRoomJpaRepository.findByBuyerIdOrSellerId(buyerId, sellerId)
+    override fun getPersonalChatList(memberId: Long): List<ChatRoomResponse> {
+        return chatRoomQueryDslRepository.getPersonalChatList(memberId)
     }
 
     override fun removeChat(chatRoom: ChatRoomEntity) {

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/hibernate/chat/ChatRoomQueryDslRepository.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/hibernate/chat/ChatRoomQueryDslRepository.kt
@@ -1,0 +1,8 @@
+package com.challengeteamkotlin.campdaddy.infrastructure.hibernate.chat
+
+import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.ChatRoomResponse
+
+interface ChatRoomQueryDslRepository {
+
+    fun getPersonalChatList(memberId: Long): List<ChatRoomResponse>
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/hibernate/chat/ChatRoomQueryDslRepositoryImpl.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/hibernate/chat/ChatRoomQueryDslRepositoryImpl.kt
@@ -1,0 +1,41 @@
+package com.challengeteamkotlin.campdaddy.infrastructure.hibernate.chat
+
+import com.challengeteamkotlin.campdaddy.domain.model.chat.QChatMessageEntity
+import com.challengeteamkotlin.campdaddy.domain.model.chat.QChatRoomEntity
+import com.challengeteamkotlin.campdaddy.domain.model.member.QMemberEntity
+import com.challengeteamkotlin.campdaddy.domain.model.product.QProductImageEntity
+import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.ChatRoomResponse
+import com.querydsl.core.types.Projections
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.stereotype.Repository
+
+@Repository
+class ChatRoomQueryDslRepositoryImpl(
+    private val queryFactory: JPAQueryFactory,
+) : ChatRoomQueryDslRepository {
+
+    private val chatRoom = QChatRoomEntity.chatRoomEntity
+    private val member = QMemberEntity.memberEntity
+    private val productImage = QProductImageEntity.productImageEntity
+    private val chatMessage = QChatMessageEntity.chatMessageEntity
+
+    override fun getPersonalChatList(memberId: Long): List<ChatRoomResponse> {
+        return queryFactory.select(
+            Projections.constructor(
+                ChatRoomResponse::class.java,
+                member.nickname,
+                productImage.imageUrl,
+                chatMessage.message,
+                chatMessage.createdAt
+            )
+        )
+            .from(chatRoom)
+            .innerJoin(member)
+            .on(member.id.eq(chatRoom.seller.id).or(member.id.eq(chatRoom.buyer.id)).and(member.id.ne(memberId)))
+            .innerJoin(chatMessage).on(chatMessage.chatRoom.id.eq(chatRoom.id))
+            .leftJoin(productImage).on(chatRoom.product.id.eq(productImage.product.id))
+            .where(chatRoom.buyer.id.eq(memberId).or(chatRoom.seller.id.eq(memberId)))
+            .groupBy(chatRoom.id)
+            .fetch()
+    }
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/hibernate/querydsl/QueryDslSupport.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/hibernate/querydsl/QueryDslSupport.kt
@@ -1,0 +1,16 @@
+package com.challengeteamkotlin.campdaddy.infrastructure.hibernate.querydsl
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class QueryDslSupport(
+    @PersistenceContext
+    private var entityManager: EntityManager
+) {
+    @Bean
+    fun queryFactory() = JPAQueryFactory(entityManager)
+}

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/ChatRoomController.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/ChatRoomController.kt
@@ -1,10 +1,12 @@
 package com.challengeteamkotlin.campdaddy.presentation.chat
 
 import com.challengeteamkotlin.campdaddy.application.chat.ChatRoomService
+import com.challengeteamkotlin.campdaddy.common.security.UserPrincipal
 import com.challengeteamkotlin.campdaddy.presentation.chat.dto.request.CreateChatRoomRequest
 import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.ChatRoomDetailResponse
 import com.challengeteamkotlin.campdaddy.presentation.chat.dto.response.ChatRoomResponse
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 import java.net.URI
 
@@ -21,22 +23,31 @@ class ChatRoomController(
     }
 
     @GetMapping("/me/{memberId}")
-    fun getChatList(@PathVariable memberId: Long): ResponseEntity<List<ChatRoomResponse>> {
-        val chatList = chatRoomService.getPersonalChatList(memberId)
+    fun getChatList(
+        @PathVariable memberId: Long,
+        @AuthenticationPrincipal userPrincipal: UserPrincipal
+    ): ResponseEntity<List<ChatRoomResponse>> {
+        val chatList = chatRoomService.getPersonalChatList(memberId, userPrincipal)
 
         return ResponseEntity.ok().body(chatList)
     }
 
     @GetMapping("/{roomId}")
-    fun getChat(@PathVariable roomId: Long): ResponseEntity<ChatRoomDetailResponse> {
-        val chatList = chatRoomService.getChatDetail(roomId)
+    fun getChat(
+        @PathVariable roomId: Long,
+        @AuthenticationPrincipal userPrincipal: UserPrincipal
+    ): ResponseEntity<ChatRoomDetailResponse> {
+        val chatList = chatRoomService.getChatDetail(roomId, userPrincipal)
 
         return ResponseEntity.ok().body(chatList)
     }
 
     @DeleteMapping("/{roomId}")
-    fun removeChat(@PathVariable roomId: Long): ResponseEntity<Unit> {
-        chatRoomService.removeChat(roomId)
+    fun removeChat(
+        @PathVariable roomId: Long,
+        @AuthenticationPrincipal userPrincipal: UserPrincipal
+    ): ResponseEntity<Unit> {
+        chatRoomService.removeChat(roomId, userPrincipal)
 
         return ResponseEntity.noContent().build()
     }

--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/context/repository/ChatConfig.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/presentation/chat/context/repository/ChatConfig.kt
@@ -6,6 +6,7 @@ import com.challengeteamkotlin.campdaddy.domain.repository.chat.ChatRoomReposito
 import com.challengeteamkotlin.campdaddy.domain.repository.chat.ChatRoomRepositoryImpl
 import com.challengeteamkotlin.campdaddy.infrastructure.hibernate.chat.ChatMessageJpaRepository
 import com.challengeteamkotlin.campdaddy.infrastructure.hibernate.chat.ChatRoomJpaRepository
+import com.challengeteamkotlin.campdaddy.infrastructure.hibernate.chat.ChatRoomQueryDslRepository
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -18,7 +19,10 @@ class ChatConfig {
     }
 
     @Bean
-    fun chatRoomRepository(jpaRepository: ChatRoomJpaRepository): ChatRoomRepository {
-        return ChatRoomRepositoryImpl(jpaRepository)
+    fun chatRoomRepository(
+        jpaRepository: ChatRoomJpaRepository,
+        chatRoomQueryDslRepository: ChatRoomQueryDslRepository
+        ): ChatRoomRepository {
+        return ChatRoomRepositoryImpl(jpaRepository, chatRoomQueryDslRepository)
     }
 }

--- a/src/test/kotlin/com/challengeteamkotlin/campdaddy/application/chat/ChatRoomServiceTest.kt
+++ b/src/test/kotlin/com/challengeteamkotlin/campdaddy/application/chat/ChatRoomServiceTest.kt
@@ -20,6 +20,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
+import userPrincipal
 
 class ChatRoomServiceTest(
     private val chatRoomService: ChatRoomService = mockk(),
@@ -50,17 +51,17 @@ class ChatRoomServiceTest(
     Given("멤버 개인 채팅방 리스트 조회 테스트") {
 
         When("유저의 ID로 조회되는 채팅방이 없으면") {
-            every { chatRoomService.getPersonalChatList(memberId) } returns emptyList()
+            every { chatRoomService.getPersonalChatList(memberId, userPrincipal) } returns emptyList()
 
             Then("빈 리스트를 리턴한다.") {
-                val emptyList = chatRoomService.getPersonalChatList(memberId)
+                val emptyList = chatRoomService.getPersonalChatList(memberId, userPrincipal)
                 emptyList shouldBe emptyList()
             }
         }
 
         When("유저의 ID로 조회되는 채팅방이 있으면") {
-            every { chatRoomService.getPersonalChatList(memberId) } returns personalChatRoomResponse
-            val personalChatRoomResponse = chatRoomService.getPersonalChatList(memberId)
+            every { chatRoomService.getPersonalChatList(memberId, userPrincipal) } returns personalChatRoomResponse
+            val personalChatRoomResponse = chatRoomService.getPersonalChatList(memberId, userPrincipal)
 
             Then("상대방 닉네임, 상품 이미지, 마지막 메세지, 마지막 메세지의 날짜 정보를 가진 채팅방 리스트를 리턴한다.") {
                 personalChatRoomResponse?.map {
@@ -73,8 +74,8 @@ class ChatRoomServiceTest(
     Given("채팅방 조회 테스트") {
 
         When("채팅방 ID로 조회할 때 채팅방이 존재하면") {
-            every { chatRoomService.getChatDetail(any()) } returns chatRoomResponse
-            val existChatRoomResponse =  chatRoomService.getChatDetail(existChatRoomId)
+            every { chatRoomService.getChatDetail(any(), any()) } returns chatRoomResponse
+            val existChatRoomResponse =  chatRoomService.getChatDetail(existChatRoomId, userPrincipal)
             Then("채팅방의 메세지, 상품 정보와 함께 방을 리턴한다.") {
                 existChatRoomResponse.chatHistory shouldBe chatMessageResponse
                 existChatRoomResponse.productDetail shouldBe productDetail
@@ -82,10 +83,10 @@ class ChatRoomServiceTest(
         }
 
         When("채팅방 ID로 조회할 때 채팅방이 존재하지 않으면") {
-            every { chatRoomService.getChatDetail(wrongChatRoomId) } throws EntityNotFoundException(ChatErrorCode.CHAT_NOT_FOUND)
+            every { chatRoomService.getChatDetail(wrongChatRoomId, userPrincipal) } throws EntityNotFoundException(ChatErrorCode.CHAT_NOT_FOUND)
 
             Then("예외가 던져진다.") {
-                val exception = shouldThrowExactly<EntityNotFoundException> { chatRoomService.getChatDetail(wrongChatRoomId) }
+                val exception = shouldThrowExactly<EntityNotFoundException> { chatRoomService.getChatDetail(wrongChatRoomId, userPrincipal) }
 
                 exception.errorCode shouldBe ChatErrorCode.CHAT_NOT_FOUND
             }
@@ -95,12 +96,12 @@ class ChatRoomServiceTest(
     Given("채팅방 삭제 테스트") {
 
         When("채팅방 ID로 삭제를 시도할 때 채팅방이 존재하면") {
-            every { chatRoomService.removeChat(existChatRoomId) } just runs
-            every { chatRoomService.getChatDetail(existChatRoomId) } throws EntityNotFoundException(ChatErrorCode.CHAT_NOT_FOUND)
+            every { chatRoomService.removeChat(existChatRoomId, userPrincipal) } just runs
+            every { chatRoomService.getChatDetail(existChatRoomId, userPrincipal) } throws EntityNotFoundException(ChatErrorCode.CHAT_NOT_FOUND)
             every { chatMessageRepository.getChatMessageByChatRoomId(existChatRoomId) } returns emptyList()
             Then("해당 채팅방과 안에 담긴 메세지는 모두 삭제되고, 재조회는 되지 않는다") {
                 val emptyChatHistory = chatMessageRepository.getChatMessageByChatRoomId(existChatRoomId)
-                val exception = shouldThrowExactly<EntityNotFoundException> { chatRoomService.getChatDetail(existChatRoomId) }
+                val exception = shouldThrowExactly<EntityNotFoundException> { chatRoomService.getChatDetail(existChatRoomId, userPrincipal) }
 
                 exception.errorCode shouldBe ChatErrorCode.CHAT_NOT_FOUND
 
@@ -108,9 +109,9 @@ class ChatRoomServiceTest(
             }
         }
         When("채팅방 ID로 삭제를 시도할 때 채팅방이 존재하지 않으면") {
-            every { chatRoomService.getChatDetail(wrongChatRoomId) } throws EntityNotFoundException(ChatErrorCode.CHAT_NOT_FOUND)
+            every { chatRoomService.getChatDetail(wrongChatRoomId, userPrincipal) } throws EntityNotFoundException(ChatErrorCode.CHAT_NOT_FOUND)
             Then("예외가 던져진다.") {
-                val exception = shouldThrowExactly<EntityNotFoundException> { chatRoomService.getChatDetail(wrongChatRoomId) }
+                val exception = shouldThrowExactly<EntityNotFoundException> { chatRoomService.getChatDetail(wrongChatRoomId, userPrincipal) }
 
                 exception.errorCode shouldBe ChatErrorCode.CHAT_NOT_FOUND
             }

--- a/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/auth/AuthFixture.kt
+++ b/src/test/kotlin/com/challengeteamkotlin/campdaddy/fixture/auth/AuthFixture.kt
@@ -1,3 +1,5 @@
+import com.challengeteamkotlin.campdaddy.common.security.UserPrincipal
+
 //package com.challengeteamkotlin.campdaddy.fixture.auth
 //
 //import com.challengeteamkotlin.campdaddy.common.security.UserPrincipal
@@ -40,3 +42,5 @@
 //    // jwtToken, jwtTokenNickname
 //    val succeedJwtToken = "success"
 //}
+
+val userPrincipal = UserPrincipal(999, "access@mail.com", setOf("MEMBER"))


### PR DESCRIPTION
## 연관 이슈
- closes #128 

## 해당 작업을 추가/변경한 이유는 무엇인가요?
- 기존 개인 채팅방 목록 조회가 1번 요청에 쿼리가 6개가 날라가서 이를 개선하고자, queryDSL을 통해 JOIN을 사용하여 쿼리를 개선하고자 했습니다.
- 이 외에는 인가 처리를 추가했습니다.

## 어떤 부분에 리뷰어가 집중하면 좋을까요?
- Query 개선을 좀 더 할 수 있을 것 같은데 더 찾아보겠습니다.

## 리뷰어에게 추가/변경 내용을 상세히 설명해주세요!
- [x] UserAuthorization.kt 수정
- [x] 개인 채팅방 목록 조회 쿼리 개선(QueryDSL)
- [x] QueryDSL 설정 추가
- [x] 채팅방 인가 처리 추가
