### PR TITLE
🐛 Bugfix: jwt filter header bearer null 버그 파악 및 해결

### DIFF
--- a/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/jwt/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/challengeteamkotlin/campdaddy/infrastructure/jwt/JwtAuthenticationFilter.kt
@@ -43,8 +43,6 @@ class JwtAuthenticationFilter(
                 }
         }
 
-        response.addHeader(HttpHeaders.AUTHORIZATION, "Bearer $jwt")
-
         filterChain.doFilter(request, response)
     }
 


### PR DESCRIPTION
## 연관 이슈
- closes #139 

## 해당 작업을 추가/변경한 이유는 무엇인가요?
- sign up 성공하면 컨트롤러에서 헤더에 bearer + 토큰이 표시되게 해놨는데 jwt filter에서도 헤더에 추가를 하게끔 했으나 필요없는 코드 였음

## 어떤 부분에 리뷰어가 집중하면 좋을까요?
- 궁금한점 문의주세요

## 리뷰어에게 추가/변경 내용을 상세히 설명해주세요!
- [x] jwt filter에서 헤더에 bearer 토큰 담는 코드 삭제
